### PR TITLE
Add binary protocol/prepared statement support

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ It's currently in production use on github.com.
 
 ## Limitations
 
-* Only supports the parts of the text protocol that are in common use. There's no support for the binary protocol or prepared statements
+* Only supports the parts of the text protocol that are in common use.
 
 * No support for `LOAD DATA INFILE` on local files
 

--- a/README.md
+++ b/README.md
@@ -11,6 +11,8 @@ It's currently in production use on github.com.
     * Password authentication
     * Query, ping, and quit commands
 
+* Support prepared statements (binary protocol)
+
 * Low-level protocol API completely decoupled from IO
 
 * Non-blocking client API wrapping the protocol API

--- a/inc/trilogy/blocking.h
+++ b/inc/trilogy/blocking.h
@@ -177,4 +177,19 @@ int trilogy_ping(trilogy_conn_t *conn);
  */
 int trilogy_close(trilogy_conn_t *conn);
 
+int trilogy_stmt_prepare(trilogy_conn_t *conn, const char *stmt, size_t stmt_len, trilogy_stmt_t *stmt_out);
+
+int trilogy_stmt_execute(trilogy_conn_t *conn, trilogy_stmt_t *stmt, uint8_t flags, trilogy_binary_value_t *binds,
+                         uint64_t *column_count_out);
+
+int trilogy_stmt_bind_data(trilogy_conn_t *conn, trilogy_stmt_t *stmt, uint16_t param_num, uint8_t *data,
+                           size_t data_len);
+
+int trilogy_stmt_read_full_row(trilogy_conn_t *conn, trilogy_stmt_t *stmt, trilogy_column_packet_t *columns,
+                               trilogy_binary_value_t *values_out);
+
+int trilogy_stmt_reset(trilogy_conn_t *conn, trilogy_stmt_t *stmt);
+
+int trilogy_stmt_close(trilogy_conn_t *conn, trilogy_stmt_t *stmt);
+
 #endif

--- a/inc/trilogy/builder.h
+++ b/inc/trilogy/builder.h
@@ -117,6 +117,10 @@ int trilogy_builder_write_uint32(trilogy_builder_t *builder, uint32_t val);
  */
 int trilogy_builder_write_uint64(trilogy_builder_t *builder, uint64_t val);
 
+int trilogy_builder_write_float(trilogy_builder_t *builder, float val);
+
+int trilogy_builder_write_double(trilogy_builder_t *builder, double val);
+
 /* trilogy_builder_write_lenenc - Append a length-encoded integer to the packet
  * buffer.
  *

--- a/inc/trilogy/builder.h
+++ b/inc/trilogy/builder.h
@@ -117,8 +117,30 @@ int trilogy_builder_write_uint32(trilogy_builder_t *builder, uint32_t val);
  */
 int trilogy_builder_write_uint64(trilogy_builder_t *builder, uint64_t val);
 
+/* trilogy_builder_write_float - Append a float to the packet buffer.
+ *
+ * builder - A pre-initialized trilogy_builder_t pointer
+ * val     - The value to append to the buffer
+ *
+ * Return values:
+ *   TRILOGY_OK     - The value was appended to the packet buffer.
+ *   TRILOGY_SYSERR - A system error occurred, check errno.
+ *   TRILOGY_MAX_PACKET_EXCEEDED - Appending this value would exceed the maximum
+ *                                 packet size.
+ */
 int trilogy_builder_write_float(trilogy_builder_t *builder, float val);
 
+/* trilogy_builder_write_double - Append a double to the packet buffer.
+ *
+ * builder - A pre-initialized trilogy_builder_t pointer
+ * val     - The value to append to the buffer
+ *
+ * Return values:
+ *   TRILOGY_OK     - The value was appended to the packet buffer.
+ *   TRILOGY_SYSERR - A system error occurred, check errno.
+ *   TRILOGY_MAX_PACKET_EXCEEDED - Appending this value would exceed the maximum
+ *                                 packet size.
+ */
 int trilogy_builder_write_double(trilogy_builder_t *builder, double val);
 
 /* trilogy_builder_write_lenenc - Append a length-encoded integer to the packet

--- a/inc/trilogy/client.h
+++ b/inc/trilogy/client.h
@@ -601,28 +601,212 @@ void trilogy_free(trilogy_conn_t *conn);
  */
 int trilogy_discard(trilogy_conn_t *conn);
 
+/* trilogy_stmt_prepare_send - Send a prepared statement prepare command to the server.
+ *
+ * conn - A connected trilogy_conn_t pointer. Using a disconnected trilogy_conn_t is
+ *        undefined.
+ *
+ * Return values:
+ *   TRILOGY_OK     - The quit command was successfully sent to the server.
+ *   TRILOGY_AGAIN  - The socket wasn't ready for writing. The caller should wait
+ *                    for writeability using `conn->sock`. Then call
+ *                    trilogy_flush_writes.
+ *   TRILOGY_SYSERR - A system error occurred, check errno.
+ */
 int trilogy_stmt_prepare_send(trilogy_conn_t *conn, const char *stmt, size_t stmt_len);
 
 /* trilogy_stmt_t - The trilogy client's prepared statement type.
  */
 typedef trilogy_stmt_ok_packet_t trilogy_stmt_t;
 
+/* trilogy_stmt_prepare_recv - Read the prepared statement prepare command response
+ * from the MySQL-compatible server.
+ *
+ * This should be called after all data written by trilogy_stmt_prepare_send is flushed
+ * to the network. Calling this at any other time during the connection
+ * lifecycle is undefined.
+ *
+ * Following a successful call to this function, the caller will also need to read off
+ * `trilogy_stmt_t.column_count` parameters as column packets, then
+ * `trilogy_stmt_t.column_count` columns as column packets. This must be done before
+ * the socket will be command-ready again.
+ *
+ * conn     - A pre-initialized trilogy_conn_t pointer. It can also be connected but
+ *          a disconnected trilogy_conn_t will also return TRILOGY_OK.
+ * stmt_out - A pointer to a pre-allocated trilogy_stmt_t.
+ *
+ * Return values:
+ *   TRILOGY_OK                 - The prepare command response successfully read from
+ *                                the server.
+ *   TRILOGY_AGAIN              - The socket wasn't ready for reading. The caller
+ *                                should wait for readability using `conn->sock`.
+ *                                Then call this function until it returns a
+ *                                different value.
+ *   TRILOGY_UNEXPECTED_PACKET  - The response packet wasn't what was expected.
+ *   TRILOGY_PROTOCOL_VIOLATION - An error occurred while processing a network
+ *                                packet.
+ *   TRILOGY_SYSERR             - A system error occurred, check errno.
+ */
 int trilogy_stmt_prepare_recv(trilogy_conn_t *conn, trilogy_stmt_t *stmt_out);
 
+/* trilogy_stmt_bind_data_send - Send a prepared statement bind long data command to the server.
+ *
+ * There is no pairing `trilogy_stmt_bind_data_recv` fucntion to this one because the server
+ * doesn't send a response to this command.
+ *
+ * conn      - A connected trilogy_conn_t pointer. Using a disconnected trilogy_conn_t is
+ *             undefined.
+ * stmt      - Pointer to a valid trilogy_stmt_t, representing the prepared statement for which
+ *             to bind the supplied parameter data to.
+ * param_num - The parameter index for which the supplied data should be bound to.
+ * data      - A pointer to the buffer containing the data to be bound.
+ * data_len  - The length of the data buffer.
+ *
+ * Return values:
+ *   TRILOGY_OK     - The bind data command was successfully sent to the server.
+ *   TRILOGY_AGAIN  - The socket wasn't ready for writing. The caller should wait
+ *                    for writeability using `conn->sock`. Then call
+ *                    trilogy_flush_writes.
+ *   TRILOGY_SYSERR - A system error occurred, check errno.
+ */
 int trilogy_stmt_bind_data_send(trilogy_conn_t *conn, trilogy_stmt_t *stmt, uint16_t param_num, uint8_t *data,
                                 size_t data_len);
 
+/* trilogy_stmt_execute_send - Send a prepared statement execute command to the server.
+ *
+ * conn  - A connected trilogy_conn_t pointer. Using a disconnected trilogy_conn_t is
+ *         undefined.
+ * stmt  - Pointer to a valid trilogy_stmt_t, representing the prepared statement you're
+ *         requesting to execute.
+ * flags - The flags (TRILOGY_STMT_FLAGS_t) to be used with this execute command packet.
+ * binds - Pointer to an array of trilogy_binary_value_t's. The array size should match that
+ *         of `trilogy_stmt_t.column_count`.
+ *
+ * Return values:
+ *   TRILOGY_OK     - The execute command was successfully sent to the server.
+ *   TRILOGY_AGAIN  - The socket wasn't ready for writing. The caller should wait
+ *                    for writeability using `conn->sock`. Then call
+ *                    trilogy_flush_writes.
+ *   TRILOGY_SYSERR - A system error occurred, check errno.
+ */
 int trilogy_stmt_execute_send(trilogy_conn_t *conn, trilogy_stmt_t *stmt, uint8_t flags, trilogy_binary_value_t *binds);
 
+/* trilogy_stmt_execute_recv - Read the prepared statement execute command response
+ * from the MySQL-compatible server.
+ *
+ * This should be called after all data written by trilogy_stmt_execute_send is flushed
+ * to the network. Calling this at any other time during the connection
+ * lifecycle is undefined.
+ *
+ * conn             - A pre-initialized trilogy_conn_t pointer. It can also be connected but
+ *                    a disconnected trilogy_conn_t will also return TRILOGY_OK.
+ * column_count_out - Out parameter; A pointer to a pre-allocated uint64_t. Represents the
+ *                    number of columns in the response.
+ *
+ * Return values:
+ *   TRILOGY_OK                 - The prepare command response successfully read from
+ *                                the server.
+ *   TRILOGY_AGAIN              - The socket wasn't ready for reading. The caller
+ *                                should wait for readability using `conn->sock`.
+ *                                Then call this function until it returns a
+ *                                different value.
+ *   TRILOGY_UNEXPECTED_PACKET  - The response packet wasn't what was expected.
+ *   TRILOGY_PROTOCOL_VIOLATION - An error occurred while processing a network
+ *                                packet.
+ *   TRILOGY_SYSERR             - A system error occurred, check errno.
+ */
 int trilogy_stmt_execute_recv(trilogy_conn_t *conn, uint64_t *column_count_out);
 
+/* trilogy_stmt_read_row - Read a row from the prepared statement execute response.
+ *
+ * This should only be called after a sucessful call to trilogy_stmt_execute_recv.
+ * You should continue calling this until TRILOGY_EOF is returned. Denoting the end
+ * of the result set.
+ *
+ * conn         - A pre-initialized trilogy_conn_t pointer. It can also be connected but
+ *                a disconnected trilogy_conn_t will also return TRILOGY_OK.
+ * stmt         - Pointer to a valid trilogy_stmt_t, representing the prepared statement you're
+ *                requesting to execute.
+ * columns      - The list of columns from the prepared statement.
+ * column_count - The number of columns in prepared statement.
+ * values_out   - Out parameter; A pointer to a pre-allocated array of
+ *                trilogy_binary_value_t's. There must be enough space to fit all of the
+ *                values. This can be computed with:
+ *                `(sizeof(trilogy_binary_value_t) * column_count)`.
+ *
+ * Return values:
+ *   TRILOGY_OK                 - The prepare command response successfully read from
+ *                                the server.
+ *   TRILOGY_AGAIN              - The socket wasn't ready for reading. The caller
+ *                                should wait for readability using `conn->sock`.
+ *                                Then call this function until it returns a
+ *                                different value.
+ *   TRILOGY_EOF                - There are no more rows to read from the result set.
+ *   TRILOGY_UNEXPECTED_PACKET  - The response packet wasn't what was expected.
+ *   TRILOGY_PROTOCOL_VIOLATION - Invalid length parsed for a TIME/DATETIME/TIMESTAMP value.
+ *   TRILOGY_UNKNOWN_TYPE       - An unsupported or unknown MySQL type was seen.
+ *   TRILOGY_SYSERR             - A system error occurred, check errno.
+ */
 int trilogy_stmt_read_row(trilogy_conn_t *conn, trilogy_stmt_t *stmt, trilogy_column_packet_t *columns,
                           trilogy_binary_value_t *values_out);
 
+/* trilogy_stmt_reset_send - Send a prepared statement reset command to the server.
+ *
+ * conn  - A connected trilogy_conn_t pointer. Using a disconnected trilogy_conn_t is
+ *         undefined.
+ * stmt  - Pointer to a valid trilogy_stmt_t, representing the prepared statement you're
+ *         requesting to reset.
+ *
+ * Return values:
+ *   TRILOGY_OK     - The reset command was successfully sent to the server.
+ *   TRILOGY_AGAIN  - The socket wasn't ready for writing. The caller should wait
+ *                    for writeability using `conn->sock`. Then call
+ *                    trilogy_flush_writes.
+ *   TRILOGY_SYSERR - A system error occurred, check errno.
+ */
 int trilogy_stmt_reset_send(trilogy_conn_t *conn, trilogy_stmt_t *stmt);
 
+/* trilogy_stmt_reset_recv - Read the prepared statement reset command response
+ * from the MySQL-compatible server.
+ *
+ * This should be called after all data written by trilogy_stmt_reset_send is flushed
+ * to the network. Calling this at any other time during the connection
+ * lifecycle is undefined.
+ *
+ * conn - A pre-initialized trilogy_conn_t pointer. It can also be connected but
+ *      a disconnected trilogy_conn_t will also return TRILOGY_OK.
+ *
+ * Return values:
+ *   TRILOGY_OK                 - The reset command response successfully read from
+ *                                the server.
+ *   TRILOGY_AGAIN              - The socket wasn't ready for reading. The caller
+ *                                should wait for readability using `conn->sock`.
+ *                                Then call this function until it returns a
+ *                                different value.
+ *   TRILOGY_UNEXPECTED_PACKET  - The response packet wasn't what was expected.
+ *   TRILOGY_PROTOCOL_VIOLATION - An error occurred while processing a network
+ *                                packet.
+ *   TRILOGY_SYSERR             - A system error occurred, check errno.
+ */
 int trilogy_stmt_reset_recv(trilogy_conn_t *conn);
 
+/* trilogy_stmt_close_send - Send a prepared statement close command to the server.
+ *
+ * There is no pairing `trilogy_stmt_close_recv` fucntion to this one because the server
+ * doesn't send a response to this command.
+ *
+ * conn  - A connected trilogy_conn_t pointer. Using a disconnected trilogy_conn_t is
+ *         undefined.
+ * stmt  - Pointer to a valid trilogy_stmt_t, representing the prepared statement you're
+ *         requesting to close.
+ *
+ * Return values:
+ *   TRILOGY_OK     - The close command was successfully sent to the server.
+ *   TRILOGY_AGAIN  - The socket wasn't ready for writing. The caller should wait
+ *                    for writeability using `conn->sock`. Then call
+ *                    trilogy_flush_writes.
+ *   TRILOGY_SYSERR - A system error occurred, check errno.
+ */
 int trilogy_stmt_close_send(trilogy_conn_t *conn, trilogy_stmt_t *stmt);
 
 #endif

--- a/inc/trilogy/client.h
+++ b/inc/trilogy/client.h
@@ -603,8 +603,10 @@ int trilogy_discard(trilogy_conn_t *conn);
 
 /* trilogy_stmt_prepare_send - Send a prepared statement prepare command to the server.
  *
- * conn - A connected trilogy_conn_t pointer. Using a disconnected trilogy_conn_t is
- *        undefined.
+ * conn     - A connected trilogy_conn_t pointer. Using a disconnected trilogy_conn_t is
+ *            undefined.
+ * stmt     - A pointer to the buffer containing the statement to prepare.
+ * stmt_len - The length of the data buffer.
  *
  * Return values:
  *   TRILOGY_OK     - The quit command was successfully sent to the server.
@@ -646,6 +648,7 @@ typedef trilogy_stmt_ok_packet_t trilogy_stmt_t;
  *   TRILOGY_PROTOCOL_VIOLATION - An error occurred while processing a network
  *                                packet.
  *   TRILOGY_SYSERR             - A system error occurred, check errno.
+ *   TRILOGY_CLOSED_CONNECTION  - The connection is closed.
  */
 int trilogy_stmt_prepare_recv(trilogy_conn_t *conn, trilogy_stmt_t *stmt_out);
 
@@ -714,6 +717,7 @@ int trilogy_stmt_execute_send(trilogy_conn_t *conn, trilogy_stmt_t *stmt, uint8_
  *   TRILOGY_PROTOCOL_VIOLATION - An error occurred while processing a network
  *                                packet.
  *   TRILOGY_SYSERR             - A system error occurred, check errno.
+ *   TRILOGY_CLOSED_CONNECTION  - The connection is closed.
  */
 int trilogy_stmt_execute_recv(trilogy_conn_t *conn, uint64_t *column_count_out);
 
@@ -746,6 +750,7 @@ int trilogy_stmt_execute_recv(trilogy_conn_t *conn, uint64_t *column_count_out);
  *   TRILOGY_PROTOCOL_VIOLATION - Invalid length parsed for a TIME/DATETIME/TIMESTAMP value.
  *   TRILOGY_UNKNOWN_TYPE       - An unsupported or unknown MySQL type was seen.
  *   TRILOGY_SYSERR             - A system error occurred, check errno.
+ *   TRILOGY_CLOSED_CONNECTION  - The connection is closed.
  */
 int trilogy_stmt_read_row(trilogy_conn_t *conn, trilogy_stmt_t *stmt, trilogy_column_packet_t *columns,
                           trilogy_binary_value_t *values_out);
@@ -787,6 +792,7 @@ int trilogy_stmt_reset_send(trilogy_conn_t *conn, trilogy_stmt_t *stmt);
  *   TRILOGY_PROTOCOL_VIOLATION - An error occurred while processing a network
  *                                packet.
  *   TRILOGY_SYSERR             - A system error occurred, check errno.
+ *   TRILOGY_CLOSED_CONNECTION  - The connection is closed.
  */
 int trilogy_stmt_reset_recv(trilogy_conn_t *conn);
 

--- a/inc/trilogy/client.h
+++ b/inc/trilogy/client.h
@@ -601,4 +601,28 @@ void trilogy_free(trilogy_conn_t *conn);
  */
 int trilogy_discard(trilogy_conn_t *conn);
 
+int trilogy_stmt_prepare_send(trilogy_conn_t *conn, const char *stmt, size_t stmt_len);
+
+/* trilogy_stmt_t - The trilogy client's prepared statement type.
+ */
+typedef trilogy_stmt_ok_packet_t trilogy_stmt_t;
+
+int trilogy_stmt_prepare_recv(trilogy_conn_t *conn, trilogy_stmt_t *stmt_out);
+
+int trilogy_stmt_bind_data_send(trilogy_conn_t *conn, trilogy_stmt_t *stmt, uint16_t param_num, uint8_t *data,
+                                size_t data_len);
+
+int trilogy_stmt_execute_send(trilogy_conn_t *conn, trilogy_stmt_t *stmt, uint8_t flags, trilogy_binary_value_t *binds);
+
+int trilogy_stmt_execute_recv(trilogy_conn_t *conn, uint64_t *column_count_out);
+
+int trilogy_stmt_read_row(trilogy_conn_t *conn, trilogy_stmt_t *stmt, trilogy_column_packet_t *columns,
+                          trilogy_binary_value_t *values_out);
+
+int trilogy_stmt_reset_send(trilogy_conn_t *conn, trilogy_stmt_t *stmt);
+
+int trilogy_stmt_reset_recv(trilogy_conn_t *conn);
+
+int trilogy_stmt_close_send(trilogy_conn_t *conn, trilogy_stmt_t *stmt);
+
 #endif

--- a/inc/trilogy/error.h
+++ b/inc/trilogy/error.h
@@ -22,7 +22,8 @@
     XX(TRILOGY_UNSUPPORTED, -17)                                                                                       \
     XX(TRILOGY_DNS_ERR, -18)                                                                                           \
     XX(TRILOGY_AUTH_SWITCH, -19)                                                                                       \
-    XX(TRILOGY_MAX_PACKET_EXCEEDED, -20)
+    XX(TRILOGY_MAX_PACKET_EXCEEDED, -20)                                                                               \
+    XX(TRILOGY_UNKNOWN_TYPE, -21)
 
 enum {
 #define XX(name, code) name = code,

--- a/inc/trilogy/protocol.h
+++ b/inc/trilogy/protocol.h
@@ -621,39 +621,125 @@ typedef struct {
     size_t data_len;
 } trilogy_value_t;
 
+/* trilogy_binary_value_t - MySQL binary protocol value type
+ *
+ * See https://dev.mysql.com/doc/internals/en/binary-protocol-value.html for more detail.
+ */
 typedef struct {
+    // Flag denoting the value is NULL.
     bool is_null;
+
+    /* Flag denoting the numeric value is unsigned.
+     * If this is true, the unsigned numerical value types should be used
+     * from the `as` union below.
+     *
+     * For example, if the value's MySQL type is TRILOGY_TYPE_LONGLONG and
+     * `is_unsigned` is `true`, the caller should use the `.as.uint64` field
+     * below to access the properly unsigned value.
+     */
     bool is_unsigned;
 
+    // The MySQL column type of this value.
     TRILOGY_TYPE_t type;
 
+    /* This union is used for accessing the underlying binary type for the value.
+     * Each field member is documented with the MySQL column/value type it maps to.
+     */
     union {
+        /* MySQL types that use this field:
+         *
+         * TRILOGY_TYPE_DOUBLE
+         */
         double dbl;
 
+        /* MySQL types that use this field:
+         *
+         * TRILOGY_TYPE_LONGLONG
+         *
+         * Refer to the `is_unsigned` field above to see which member below should
+         * be used to access the value.
+         */
         int64_t int64;
         uint64_t uint64;
 
+        /* MySQL types that use this field:
+         *
+         * TRILOGY_TYPE_FLOAT
+         */
         float flt;
 
+        /* MySQL types that use this field:
+         *
+         * TRILOGY_TYPE_LONG
+         * TRILOGY_TYPE_INT24
+         *
+         * Refer to the `is_unsigned` field above to see which member below should
+         * be used to access the value.
+         */
         uint32_t uint32;
         int32_t int32;
 
+        /* MySQL types that use this field:
+         *
+         * TRILOGY_TYPE_SHORT
+         *
+         * Refer to the `is_unsigned` field above to see which member below should
+         * be used to access the value.
+         */
         uint16_t uint16;
         int16_t int16;
 
+        /* MySQL types that use this field:
+         *
+         * TRILOGY_TYPE_TINY
+         *
+         * Refer to the `is_unsigned` field above to see which member below should
+         * be used to access the value.
+         */
         uint8_t uint8;
         int8_t int8;
 
+        /* MySQL types that use this field:
+         *
+         * TRILOGY_TYPE_STRING
+         * TRILOGY_TYPE_VARCHAR
+         * TRILOGY_TYPE_VAR_STRING
+         * TRILOGY_TYPE_ENUM
+         * TRILOGY_TYPE_SET
+         * TRILOGY_TYPE_LONG_BLOB
+         * TRILOGY_TYPE_MEDIUM_BLOB
+         * TRILOGY_TYPE_BLOB
+         * TRILOGY_TYPE_TINY_BLOB
+         * TRILOGY_TYPE_GEOMETRY
+         * TRILOGY_TYPE_BIT
+         * TRILOGY_TYPE_DECIMAL
+         * TRILOGY_TYPE_NEWDECIMAL
+         */
         struct {
             const void *data;
             size_t len;
         } str;
 
+        /* MySQL types that use this field:
+         *
+         * TRILOGY_TYPE_DATE
+         * TRILOGY_TYPE_DATETIME
+         * TRILOGY_TYPE_TIMESTAMP
+         */
         struct {
+            /* MySQL types that use this field:
+             *
+             * TRILOGY_TYPE_YEAR
+             */
             uint16_t year;
+
             uint8_t month, day;
         } date;
 
+        /* MySQL types that use this field:
+         *
+         * TRILOGY_TYPE_TIME
+         */
         struct {
             bool is_negative;
             uint32_t days;

--- a/inc/trilogy/protocol.h
+++ b/inc/trilogy/protocol.h
@@ -623,6 +623,7 @@ typedef struct {
 
 typedef struct {
     bool is_null;
+    bool is_unsigned;
 
     TRILOGY_TYPE_t type;
 

--- a/inc/trilogy/protocol.h
+++ b/inc/trilogy/protocol.h
@@ -565,8 +565,6 @@ typedef struct {
 } trilogy_ok_packet_t;
 
 /* trilogy_stmt_ok_packet_t - Represents a MySQL binary protocol prepare response packet.
- *
- * See https://dev.mysql.com/doc/internals/en/com-stmt-prepare-response.html for more detail.
  */
 typedef struct {
     uint32_t id;
@@ -627,7 +625,6 @@ typedef struct {
 
 /* trilogy_binary_value_t - MySQL binary protocol value type
  *
- * See https://dev.mysql.com/doc/internals/en/binary-protocol-value.html for more detail.
  */
 typedef struct {
     // Flag denoting the value is NULL.

--- a/inc/trilogy/protocol.h
+++ b/inc/trilogy/protocol.h
@@ -564,6 +564,10 @@ typedef struct {
     size_t last_gtid_len;
 } trilogy_ok_packet_t;
 
+/* trilogy_stmt_ok_packet_t - Represents a MySQL binary protocol prepare response packet.
+ *
+ * See https://dev.mysql.com/doc/internals/en/com-stmt-prepare-response.html for more detail.
+ */
 typedef struct {
     uint32_t id;
     uint16_t column_count;

--- a/inc/trilogy/protocol.h
+++ b/inc/trilogy/protocol.h
@@ -926,7 +926,7 @@ int trilogy_parse_stmt_ok_packet(const uint8_t *buff, size_t len, trilogy_stmt_o
  * out_values   - Out parameter; A pointer to a pre-allocated array of
  *                trilogy_binary_value_t's. There must be enough space to fit all of the
  *                values. This can be computed with:
- *                `(sizeof(trilogy_value_t) * column_count)`.
+ *                `(sizeof(trilogy_binary_value_t) * column_count)`.
  *
  * Return values:
  *   TRILOGY_OK                   - The packet was was parsed and the out
@@ -934,8 +934,7 @@ int trilogy_parse_stmt_ok_packet(const uint8_t *buff, size_t len, trilogy_stmt_o
  *   TRILOGY_TRUNCATED_PACKET     - There isn't enough data in the buffer
  *                                  to parse the packet.
  *   TRILOGY_PROTOCOL_VIOLATION   - Invalid length parsed for a TIME/DATETIME/TIMESTAMP value.
- *   TRILOGY_UNKNOWN_TYPE         - An unsupported or unknown MySQL type was used in the list
- *                                  of binds.
+ *   TRILOGY_UNKNOWN_TYPE         - An unsupported or unknown MySQL type was seen in the packet.
  *   TRILOGY_EXTRA_DATA_IN_PACKET - There are unparsed bytes left in the
  *                                  buffer.
  */

--- a/inc/trilogy/protocol.h
+++ b/inc/trilogy/protocol.h
@@ -702,7 +702,7 @@ typedef enum {
 int trilogy_build_stmt_execute_packet(trilogy_builder_t *builder, uint32_t stmt_id, uint8_t flags,
                                       trilogy_binary_value_t *binds, uint16_t num_binds);
 
-/* trilogy_build_stmt_bind_data_packet - Build a prepared statement send long data command packet.
+/* trilogy_build_stmt_bind_data_packet - Build a prepared statement bind long data command packet.
  *
  * builder  - A pointer to a pre-initialized trilogy_builder_t.
  * stmt_id  - The statement id for which to build the bind data packet with.

--- a/inc/trilogy/protocol.h
+++ b/inc/trilogy/protocol.h
@@ -565,6 +565,13 @@ typedef struct {
 } trilogy_ok_packet_t;
 
 typedef struct {
+    uint32_t id;
+    uint16_t column_count;
+    uint16_t parameter_count;
+    uint16_t warning_count;
+} trilogy_stmt_ok_packet_t;
+
+typedef struct {
     uint16_t warning_count;
     uint16_t status_flags;
 } trilogy_eof_packet_t;
@@ -613,6 +620,127 @@ typedef struct {
     const void *data;
     size_t data_len;
 } trilogy_value_t;
+
+typedef struct {
+    bool is_null;
+
+    TRILOGY_TYPE_t type;
+
+    union {
+        double dbl;
+
+        int64_t int64;
+        uint64_t uint64;
+
+        float flt;
+
+        uint32_t uint32;
+        int32_t int32;
+
+        uint16_t uint16;
+        int16_t int16;
+
+        uint8_t uint8;
+        int8_t int8;
+
+        struct {
+            const void *data;
+            size_t len;
+        } str;
+
+        struct {
+            uint16_t year;
+            uint8_t month, day;
+            struct {
+                bool is_negative;
+                uint32_t days;
+                uint8_t hour, minute, second;
+                uint32_t micro_seconds;
+            } time;
+        } date;
+    } as;
+} trilogy_binary_value_t;
+
+/* trilogy_build_stmt_prepare_packet - Build a prepared statement prepare command packet.
+ *
+ * builder   - A pointer to a pre-initialized trilogy_builder_t.
+ * query     - The query string to be used by the prepared statement.
+ * query_len - The length of query in bytes.
+ *
+ * Return values:
+ *   TRILOGY_OK     - The packet was successfully built and written to the
+ *                    builder's internal buffer.
+ *   TRILOGY_SYSERR - A system error occurred, check errno.
+ */
+int trilogy_build_stmt_prepare_packet(trilogy_builder_t *builder, const char *sql, size_t sql_len);
+
+// Prepared statement flags
+typedef enum {
+    TRILOGY_CURSOR_TYPE_NO_CURSOR  = 0x00,
+    TRILOGY_CURSOR_TYPE_READ_ONLY  = 0x01,
+    TRILOGY_CURSOR_TYPE_FOR_UPDATE = 0x02,
+    TRILOGY_CURSOR_TYPE_SCROLLABLE = 0x04,
+    TRILOGY_CURSOR_TYPE_UNKNOWN
+} TRILOGY_STMT_FLAGS_t;
+
+/* trilogy_build_stmt_execute_packet - Build a prepared statement execute command packet.
+ *
+ * builder   - A pointer to a pre-initialized trilogy_builder_t.
+ * stmt_id   - The statement id for which to build the execute packet with.
+ * flags     - The flags (TRILOGY_STMT_FLAGS_t) to be used with this execute command packet.
+ * binds     - Pointer to an array of trilogy_binary_value_t's.
+ * num_binds - The number of elements in the binds array above.
+ *
+ * Return values:
+ *   TRILOGY_OK                 - The packet was successfully built and written to the
+ *                                builder's internal buffer.
+ *   TRILOGY_PROTOCOL_VIOLATION - num_binds is > 0 but binds is NULL.
+ *   TRILOGY_UNKNOWN_TYPE       - An unsupported or unknown MySQL type was used in the list
+ *                                of binds.
+ *   TRILOGY_SYSERR             - A system error occurred, check errno.
+ */
+int trilogy_build_stmt_execute_packet(trilogy_builder_t *builder, uint32_t stmt_id, uint8_t flags,
+                                      trilogy_binary_value_t *binds, uint16_t num_binds);
+
+/* trilogy_build_stmt_bind_data_packet - Build a prepared statement send long data command packet.
+ *
+ * builder  - A pointer to a pre-initialized trilogy_builder_t.
+ * stmt_id  - The statement id for which to build the bind data packet with.
+ * param_id - The parameter index for which the supplied data should be bound to.
+ * data     - A pointer to the buffer containing the data to be bound.
+ * data_len - The length of the data buffer.
+ *
+ * Return values:
+ *   TRILOGY_OK     - The packet was successfully built and written to the
+ *                    builder's internal buffer.
+ *   TRILOGY_SYSERR - A system error occurred, check errno.
+ */
+int trilogy_build_stmt_bind_data_packet(trilogy_builder_t *builder, uint32_t stmt_id, uint16_t param_id, uint8_t *data,
+                                        size_t data_len);
+
+/* trilogy_build_stmt_reset_packet - Build a prepared statement reset command packet.
+ *
+ * builder - A pointer to a pre-initialized trilogy_builder_t.
+ * stmt_id - The statement id for which to build the reset packet with.
+ *
+ * Return values:
+ *   TRILOGY_OK     - The packet was successfully built and written to the
+ *                    builder's internal buffer.
+ *   TRILOGY_SYSERR - A system error occurred, check errno.
+ */
+int trilogy_build_stmt_reset_packet(trilogy_builder_t *builder, uint32_t stmt_id);
+
+/* trilogy_build_stmt_close_packet - Build a prepared statement close command packet.
+ *
+ * builder - A pointer to a pre-initialized trilogy_builder_t.
+ * stmt_id - The statement id for which to build the close packet with.
+ *
+ * Return values:
+ *   TRILOGY_OK     - The packet was successfully built and written to the
+ *                    builder's internal buffer.
+ *   TRILOGY_SYSERR - A system error occurred, check errno.
+ */
+int trilogy_build_stmt_close_packet(trilogy_builder_t *builder, uint32_t stmt_id);
 
 /* The following parsing functions assume the buffer and length passed in point
  * to one full MySQL-compatible packet. If the buffer contains more than one packet or
@@ -769,5 +897,49 @@ int trilogy_parse_column_packet(const uint8_t *buff, size_t len, bool field_list
  *                                  buffer.
  */
 int trilogy_parse_row_packet(const uint8_t *buff, size_t len, uint64_t column_count, trilogy_value_t *out_values);
+
+/* trilogy_parse_stmt_ok_packet - Parse a prepared statement ok packet.
+ *
+ * buff         - A pointer to the buffer containing the result packet data.
+ * len          - The length of buffer in bytes.
+ * out_packet   - Out parameter; A pointer to a pre-allocated trilogy_stmt_ok_packet_t.
+ *
+ * Return values:
+ *   TRILOGY_OK                   - The packet was was parsed and the out
+ *                                  parameter has been filled in.
+ *   TRILOGY_TRUNCATED_PACKET     - There isn't enough data in the buffer
+ *                                  to parse the packet.
+ *   TRILOGY_PROTOCOL_VIOLATION   - Filler byte was something other than zero.
+ *   TRILOGY_EXTRA_DATA_IN_PACKET - There are unparsed bytes left in the
+ *                                  buffer.
+ */
+int trilogy_parse_stmt_ok_packet(const uint8_t *buff, size_t len, trilogy_stmt_ok_packet_t *out_packet);
+
+/* trilogy_parse_stmt_row_packet - Parse a prepared statement row packet.
+ *
+ * buff         - A pointer to the buffer containing the result packet data.
+ * len          - The length of buffer in bytes.
+ * columns      - The list of columns from the prepared statement. This parser needs
+ *                this in order to match up the value types.
+ * column_count - The number of columns in prepared statement. This parser needs this
+ *                in order to know how many values to parse.
+ * out_values   - Out parameter; A pointer to a pre-allocated array of
+ *                trilogy_binary_value_t's. There must be enough space to fit all of the
+ *                values. This can be computed with:
+ *                `(sizeof(trilogy_value_t) * column_count)`.
+ *
+ * Return values:
+ *   TRILOGY_OK                   - The packet was was parsed and the out
+ *                                  parameter has been filled in.
+ *   TRILOGY_TRUNCATED_PACKET     - There isn't enough data in the buffer
+ *                                  to parse the packet.
+ *   TRILOGY_PROTOCOL_VIOLATION   - Invalid length parsed for a TIME/DATETIME/TIMESTAMP value.
+ *   TRILOGY_UNKNOWN_TYPE         - An unsupported or unknown MySQL type was used in the list
+ *                                  of binds.
+ *   TRILOGY_EXTRA_DATA_IN_PACKET - There are unparsed bytes left in the
+ *                                  buffer.
+ */
+int trilogy_parse_stmt_row_packet(const uint8_t *buff, size_t len, trilogy_column_packet_t *columns,
+                                  uint64_t column_count, trilogy_binary_value_t *out_values);
 
 #endif

--- a/inc/trilogy/protocol.h
+++ b/inc/trilogy/protocol.h
@@ -726,19 +726,19 @@ typedef struct {
 
         /* MySQL types that use this field:
          *
+         * TRILOGY_TYPE_YEAR
+         */
+        uint16_t year;
+
+        /* MySQL types that use this field:
+         *
          * TRILOGY_TYPE_DATE
          * TRILOGY_TYPE_DATETIME
          * TRILOGY_TYPE_TIMESTAMP
          */
         struct {
-            /* MySQL types that use this field:
-             *
-             * TRILOGY_TYPE_YEAR
-             */
             uint16_t year;
-
             uint8_t month, day;
-
             struct {
                 uint8_t hour, minute, second;
                 uint32_t micro_seconds;

--- a/inc/trilogy/protocol.h
+++ b/inc/trilogy/protocol.h
@@ -652,13 +652,14 @@ typedef struct {
         struct {
             uint16_t year;
             uint8_t month, day;
-            struct {
-                bool is_negative;
-                uint32_t days;
-                uint8_t hour, minute, second;
-                uint32_t micro_seconds;
-            } time;
         } date;
+
+        struct {
+            bool is_negative;
+            uint32_t days;
+            uint8_t hour, minute, second;
+            uint32_t micro_seconds;
+        } time;
     } as;
 } trilogy_binary_value_t;
 

--- a/inc/trilogy/protocol.h
+++ b/inc/trilogy/protocol.h
@@ -738,6 +738,11 @@ typedef struct {
             uint16_t year;
 
             uint8_t month, day;
+
+            struct {
+                uint8_t hour, minute, second;
+                uint32_t micro_seconds;
+            } datetime;
         } date;
 
         /* MySQL types that use this field:

--- a/inc/trilogy/reader.h
+++ b/inc/trilogy/reader.h
@@ -90,6 +90,10 @@ int trilogy_reader_get_uint32(trilogy_reader_t *reader, uint32_t *out);
  */
 int trilogy_reader_get_uint64(trilogy_reader_t *reader, uint64_t *out);
 
+int trilogy_reader_get_float(trilogy_reader_t *reader, float *out);
+
+int trilogy_reader_get_double(trilogy_reader_t *reader, double *out);
+
 /* trilogy_reader_get_lenenc - Parse an unsigned, length-encoded integer.
  *
  * reader - A pointer to a pre-initialized trilogy_reader_t.

--- a/src/builder.c
+++ b/src/builder.c
@@ -120,6 +120,48 @@ int trilogy_builder_write_uint64(trilogy_builder_t *builder, uint64_t val)
     return TRILOGY_OK;
 }
 
+typedef union {
+    float f;
+    uint32_t u;
+} trilogy_float_buf_t;
+
+int trilogy_builder_write_float(trilogy_builder_t *builder, float val)
+{
+    trilogy_float_buf_t float_val;
+
+    float_val.f = val;
+
+    CHECKED(trilogy_builder_write_uint8(builder, float_val.u & 0xff));
+    CHECKED(trilogy_builder_write_uint8(builder, (float_val.u >> 8) & 0xff));
+    CHECKED(trilogy_builder_write_uint8(builder, (float_val.u >> 16) & 0xff));
+    CHECKED(trilogy_builder_write_uint8(builder, (float_val.u >> 24) & 0xff));
+
+    return TRILOGY_OK;
+}
+
+typedef union {
+    double d;
+    uint64_t u;
+} trilogy_double_buf_t;
+
+int trilogy_builder_write_double(trilogy_builder_t *builder, double val)
+{
+    trilogy_double_buf_t double_val;
+
+    double_val.d = val;
+
+    CHECKED(trilogy_builder_write_uint8(builder, double_val.u & 0xff));
+    CHECKED(trilogy_builder_write_uint8(builder, (double_val.u >> 8) & 0xff));
+    CHECKED(trilogy_builder_write_uint8(builder, (double_val.u >> 16) & 0xff));
+    CHECKED(trilogy_builder_write_uint8(builder, (double_val.u >> 24) & 0xff));
+    CHECKED(trilogy_builder_write_uint8(builder, (double_val.u >> 32) & 0xff));
+    CHECKED(trilogy_builder_write_uint8(builder, (double_val.u >> 40) & 0xff));
+    CHECKED(trilogy_builder_write_uint8(builder, (double_val.u >> 48) & 0xff));
+    CHECKED(trilogy_builder_write_uint8(builder, (double_val.u >> 56) & 0xff));
+
+    return TRILOGY_OK;
+}
+
 int trilogy_builder_write_lenenc(trilogy_builder_t *builder, uint64_t val)
 {
     if (val < 251) {

--- a/src/builder.c
+++ b/src/builder.c
@@ -120,24 +120,12 @@ int trilogy_builder_write_uint64(trilogy_builder_t *builder, uint64_t val)
     return TRILOGY_OK;
 }
 
-#ifndef TRILOGY_FLOAT_BUF
-#define TRILOGY_FLOAT_BUF
-
-typedef union {
-    float f;
-    uint32_t u;
-} trilogy_float_buf_t;
-
-typedef union {
-    double d;
-    uint64_t u;
-} trilogy_double_buf_t;
-
-#endif
-
 int trilogy_builder_write_float(trilogy_builder_t *builder, float val)
 {
-    trilogy_float_buf_t float_val;
+    union {
+        float f;
+        uint32_t u;
+    } float_val;
 
     float_val.f = val;
 
@@ -151,7 +139,10 @@ int trilogy_builder_write_float(trilogy_builder_t *builder, float val)
 
 int trilogy_builder_write_double(trilogy_builder_t *builder, double val)
 {
-    trilogy_double_buf_t double_val;
+    union {
+        double d;
+        uint64_t u;
+    } double_val;
 
     double_val.d = val;
 

--- a/src/builder.c
+++ b/src/builder.c
@@ -120,10 +120,20 @@ int trilogy_builder_write_uint64(trilogy_builder_t *builder, uint64_t val)
     return TRILOGY_OK;
 }
 
+#ifndef TRILOGY_FLOAT_BUF
+#define TRILOGY_FLOAT_BUF
+
 typedef union {
     float f;
     uint32_t u;
 } trilogy_float_buf_t;
+
+typedef union {
+    double d;
+    uint64_t u;
+} trilogy_double_buf_t;
+
+#endif
 
 int trilogy_builder_write_float(trilogy_builder_t *builder, float val)
 {
@@ -138,11 +148,6 @@ int trilogy_builder_write_float(trilogy_builder_t *builder, float val)
 
     return TRILOGY_OK;
 }
-
-typedef union {
-    double d;
-    uint64_t u;
-} trilogy_double_buf_t;
 
 int trilogy_builder_write_double(trilogy_builder_t *builder, double val)
 {

--- a/src/client.c
+++ b/src/client.c
@@ -872,7 +872,6 @@ int trilogy_stmt_execute_recv(trilogy_conn_t *conn, uint64_t *column_count_out)
     }
 }
 
-// FYI: there is no `trilogy_stmt_bind_data_recv` because the server doesn't send a response.
 int trilogy_stmt_bind_data_send(trilogy_conn_t *conn, trilogy_stmt_t *stmt, uint16_t param_num, uint8_t *data,
                                 size_t data_len)
 {

--- a/src/client.c
+++ b/src/client.c
@@ -917,10 +917,8 @@ int trilogy_stmt_read_row(trilogy_conn_t *conn, trilogy_stmt_t *stmt, trilogy_co
 
 int trilogy_stmt_reset_send(trilogy_conn_t *conn, trilogy_stmt_t *stmt)
 {
-    int err = 0;
-
     trilogy_builder_t builder;
-    err = begin_command_phase(&builder, conn, 0);
+    int err = begin_command_phase(&builder, conn, 0);
     if (err < 0) {
         return err;
     }

--- a/src/protocol.c
+++ b/src/protocol.c
@@ -798,7 +798,6 @@ int trilogy_build_stmt_execute_packet(trilogy_builder_t *builder, uint32_t stmt_
                 CHECKED(trilogy_builder_write_uint8(builder, val.as.uint8));
 
                 break;
-            case TRILOGY_TYPE_YEAR:
             case TRILOGY_TYPE_SHORT:
                 CHECKED(trilogy_builder_write_uint16(builder, val.as.uint16));
 
@@ -818,6 +817,10 @@ int trilogy_build_stmt_execute_packet(trilogy_builder_t *builder, uint32_t stmt_
                 break;
             case TRILOGY_TYPE_DOUBLE:
                 CHECKED(trilogy_builder_write_double(builder, val.as.dbl));
+
+                break;
+            case TRILOGY_TYPE_YEAR:
+                CHECKED(trilogy_builder_write_uint16(builder, val.as.year));
 
                 break;
             case TRILOGY_TYPE_TIME: {
@@ -1062,7 +1065,7 @@ int trilogy_parse_stmt_row_packet(const uint8_t *buff, size_t len, trilogy_colum
 
                 break;
             case TRILOGY_TYPE_YEAR:
-                CHECKED(trilogy_reader_get_uint16(&reader, &out_values[i].as.date.year));
+                CHECKED(trilogy_reader_get_uint16(&reader, &out_values[i].as.year));
 
                 break;
             case TRILOGY_TYPE_TINY:

--- a/src/protocol.c
+++ b/src/protocol.c
@@ -1147,7 +1147,6 @@ int trilogy_parse_stmt_row_packet(const uint8_t *buff, size_t len, trilogy_colum
                     CHECKED(trilogy_reader_get_uint8(&reader, &out_values[i].as.time.hour));
                     CHECKED(trilogy_reader_get_uint8(&reader, &out_values[i].as.time.minute));
                     CHECKED(trilogy_reader_get_uint8(&reader, &out_values[i].as.time.second));
-                    CHECKED(trilogy_reader_get_uint32(&reader, &out_values[i].as.time.micro_seconds));
 
                     break;
                 }

--- a/src/protocol.c
+++ b/src/protocol.c
@@ -12,6 +12,12 @@
 #define TRILOGY_CMD_PING 0x0e
 #define TRILOGY_CMD_SET_OPTION 0x1b
 
+#define TRILOGY_CMD_STMT_PREPARE 0x16
+#define TRILOGY_CMD_STMT_EXECUTE 0x17
+#define TRILOGY_CMD_STMT_SEND_LONG_DATA 0x18
+#define TRILOGY_CMD_STMT_CLOSE 0x19
+#define TRILOGY_CMD_STMT_RESET 0x1a
+
 #define SCRAMBLE_LEN 20
 
 static size_t min(size_t a, size_t b)
@@ -395,6 +401,37 @@ fail:
     return rc;
 }
 
+int trilogy_parse_stmt_ok_packet(const uint8_t *buff, size_t len, trilogy_stmt_ok_packet_t *out_packet)
+{
+    int rc;
+
+    trilogy_reader_t reader = TRILOGY_READER(buff, len);
+
+    // skip packet type
+    CHECKED(trilogy_reader_get_uint8(&reader, NULL));
+
+    CHECKED(trilogy_reader_get_uint32(&reader, &out_packet->id));
+
+    CHECKED(trilogy_reader_get_uint16(&reader, &out_packet->column_count));
+
+    CHECKED(trilogy_reader_get_uint16(&reader, &out_packet->parameter_count));
+
+    uint8_t filler;
+
+    CHECKED(trilogy_reader_get_uint8(&reader, &filler));
+
+    if (filler != 0) {
+        return TRILOGY_PROTOCOL_VIOLATION;
+    }
+
+    CHECKED(trilogy_reader_get_uint16(&reader, &out_packet->warning_count));
+
+    return trilogy_reader_finish(&reader);
+
+fail:
+    return rc;
+}
+
 static void trilogy_pack_scramble_native_hash(const char *scramble, const char *password, size_t password_len,
                                               uint8_t *buffer, unsigned int *buffer_len)
 {
@@ -678,6 +715,456 @@ int trilogy_build_ssl_request_packet(trilogy_builder_t *builder, TRILOGY_CAPABIL
     trilogy_builder_finalize(builder);
 
     return TRILOGY_OK;
+
+fail:
+    return rc;
+}
+
+int trilogy_build_stmt_prepare_packet(trilogy_builder_t *builder, const char *sql, size_t sql_len)
+{
+    int rc = TRILOGY_OK;
+
+    CHECKED(trilogy_builder_write_uint8(builder, TRILOGY_CMD_STMT_PREPARE));
+
+    CHECKED(trilogy_builder_write_buffer(builder, sql, sql_len));
+
+    trilogy_builder_finalize(builder);
+
+    return TRILOGY_OK;
+
+fail:
+    return rc;
+}
+
+int trilogy_build_stmt_execute_packet(trilogy_builder_t *builder, uint32_t stmt_id, uint8_t flags,
+                                      trilogy_binary_value_t *binds, uint16_t num_binds)
+{
+    int rc = TRILOGY_OK;
+
+    CHECKED(trilogy_builder_write_uint8(builder, TRILOGY_CMD_STMT_EXECUTE));
+
+    CHECKED(trilogy_builder_write_uint32(builder, stmt_id));
+
+    CHECKED(trilogy_builder_write_uint8(builder, flags));
+
+    // apparently, iteration-count is always 1
+    CHECKED(trilogy_builder_write_uint32(builder, 1));
+
+    int i;
+
+    if (num_binds > 0) {
+        if (binds == NULL) {
+            return TRILOGY_PROTOCOL_VIOLATION;
+        }
+
+        int bind_off = 0;
+        int bm_bytes = (num_binds + 7) / 8;
+
+        for (i = 0; i < bm_bytes; i++) {
+            uint8_t nb = 0;
+
+            for (; bind_off < num_binds; bind_off++) {
+                if (binds[bind_off].is_null) {
+                    nb |= (bind_off % 8);
+                }
+            }
+
+            CHECKED(trilogy_builder_write_uint8(builder, nb));
+        }
+
+        // new params bound flag
+        CHECKED(trilogy_builder_write_uint8(builder, 0x1));
+
+        for (i = 0; i < num_binds; i++) {
+            CHECKED(trilogy_builder_write_uint8(builder, binds[i].type));
+            CHECKED(trilogy_builder_write_uint8(builder, 0x0));
+        }
+
+        for (i = 0; i < num_binds; i++) {
+            trilogy_binary_value_t val = binds[i];
+
+            switch (val.type) {
+            case TRILOGY_TYPE_TINY:
+                CHECKED(trilogy_builder_write_uint8(builder, val.as.uint8));
+
+                break;
+            case TRILOGY_TYPE_YEAR:
+            case TRILOGY_TYPE_SHORT:
+                CHECKED(trilogy_builder_write_uint16(builder, val.as.uint16));
+
+                break;
+            case TRILOGY_TYPE_INT24:
+            case TRILOGY_TYPE_LONG:
+                CHECKED(trilogy_builder_write_uint32(builder, val.as.uint32));
+
+                break;
+            case TRILOGY_TYPE_LONGLONG:
+                CHECKED(trilogy_builder_write_uint64(builder, val.as.uint64));
+
+                break;
+            case TRILOGY_TYPE_FLOAT:
+                CHECKED(trilogy_builder_write_float(builder, val.as.flt));
+
+                break;
+            case TRILOGY_TYPE_DOUBLE:
+                CHECKED(trilogy_builder_write_double(builder, val.as.dbl));
+
+                break;
+            case TRILOGY_TYPE_TIME: {
+                uint8_t field_len = 0;
+
+                if (val.as.date.time.micro_seconds) {
+                    field_len = 12;
+                } else if (val.as.date.time.hour || val.as.date.time.minute || val.as.date.time.second) {
+                    field_len = 8;
+                } else {
+                    field_len = 0;
+                }
+
+                CHECKED(trilogy_builder_write_uint8(builder, field_len));
+
+                if (field_len > 0) {
+                    CHECKED(trilogy_builder_write_uint8(builder, val.as.date.time.is_negative));
+
+                    CHECKED(trilogy_builder_write_uint32(builder, val.as.date.time.days));
+
+                    CHECKED(trilogy_builder_write_uint8(builder, val.as.date.time.hour));
+
+                    CHECKED(trilogy_builder_write_uint8(builder, val.as.date.time.minute));
+
+                    CHECKED(trilogy_builder_write_uint8(builder, val.as.date.time.second));
+
+                    if (field_len > 8) {
+                        CHECKED(trilogy_builder_write_uint32(builder, val.as.date.time.micro_seconds));
+                    }
+                }
+
+                break;
+            }
+            case TRILOGY_TYPE_DATE:
+            case TRILOGY_TYPE_DATETIME:
+            case TRILOGY_TYPE_TIMESTAMP: {
+                uint8_t field_len = 0;
+
+                if (val.as.date.time.micro_seconds) {
+                    field_len = 11;
+                } else if (val.as.date.time.hour || val.as.date.time.minute || val.as.date.time.second) {
+                    field_len = 7;
+                } else if (val.as.date.year || val.as.date.month || val.as.date.day) {
+                    field_len = 4;
+                } else {
+                    field_len = 0;
+                }
+
+                CHECKED(trilogy_builder_write_uint8(builder, field_len));
+
+                if (field_len > 0) {
+                    CHECKED(trilogy_builder_write_uint16(builder, val.as.date.year));
+
+                    CHECKED(trilogy_builder_write_uint8(builder, val.as.date.month));
+
+                    CHECKED(trilogy_builder_write_uint8(builder, val.as.date.day));
+
+                    if (field_len > 4) {
+                        CHECKED(trilogy_builder_write_uint8(builder, val.as.date.time.hour));
+
+                        CHECKED(trilogy_builder_write_uint8(builder, val.as.date.time.minute));
+
+                        CHECKED(trilogy_builder_write_uint8(builder, val.as.date.time.second));
+
+                        if (field_len > 7) {
+                            CHECKED(trilogy_builder_write_uint32(builder, val.as.date.time.micro_seconds));
+                        }
+                    }
+                }
+
+                break;
+            }
+            case TRILOGY_TYPE_DECIMAL:
+            case TRILOGY_TYPE_VARCHAR:
+            case TRILOGY_TYPE_BIT:
+            case TRILOGY_TYPE_NEWDECIMAL:
+            case TRILOGY_TYPE_ENUM:
+            case TRILOGY_TYPE_SET:
+            case TRILOGY_TYPE_TINY_BLOB:
+            case TRILOGY_TYPE_BLOB:
+            case TRILOGY_TYPE_MEDIUM_BLOB:
+            case TRILOGY_TYPE_LONG_BLOB:
+            case TRILOGY_TYPE_VAR_STRING:
+            case TRILOGY_TYPE_STRING:
+            case TRILOGY_TYPE_GEOMETRY:
+                CHECKED(trilogy_builder_write_lenenc_buffer(builder, val.as.str.data, val.as.str.len));
+
+                break;
+            case TRILOGY_TYPE_NULL:
+                // already handled by the null bitmap
+                break;
+            default:
+                return TRILOGY_UNKNOWN_TYPE;
+            }
+        }
+    }
+
+    trilogy_builder_finalize(builder);
+
+    return TRILOGY_OK;
+
+fail:
+    return rc;
+}
+
+int trilogy_build_stmt_bind_data_packet(trilogy_builder_t *builder, uint32_t stmt_id, uint16_t param_id, uint8_t *data,
+                                        size_t data_len)
+{
+    int rc = TRILOGY_OK;
+
+    CHECKED(trilogy_builder_write_uint8(builder, TRILOGY_CMD_STMT_SEND_LONG_DATA));
+
+    CHECKED(trilogy_builder_write_uint32(builder, stmt_id));
+
+    CHECKED(trilogy_builder_write_uint16(builder, param_id));
+
+    CHECKED(trilogy_builder_write_buffer(builder, data, data_len));
+
+    trilogy_builder_finalize(builder);
+
+    return TRILOGY_OK;
+
+fail:
+    return rc;
+}
+
+int trilogy_build_stmt_reset_packet(trilogy_builder_t *builder, uint32_t stmt_id)
+{
+    int rc = TRILOGY_OK;
+
+    CHECKED(trilogy_builder_write_uint8(builder, TRILOGY_CMD_STMT_RESET));
+
+    CHECKED(trilogy_builder_write_uint32(builder, stmt_id));
+
+    trilogy_builder_finalize(builder);
+
+    return TRILOGY_OK;
+
+fail:
+    return rc;
+}
+
+int trilogy_build_stmt_close_packet(trilogy_builder_t *builder, uint32_t stmt_id)
+{
+    int rc = TRILOGY_OK;
+
+    CHECKED(trilogy_builder_write_uint8(builder, TRILOGY_CMD_STMT_CLOSE));
+
+    CHECKED(trilogy_builder_write_uint32(builder, stmt_id));
+
+    trilogy_builder_finalize(builder);
+
+    return TRILOGY_OK;
+
+fail:
+    return rc;
+}
+
+static inline int is_null(uint8_t *null_bitmap, uint64_t bitmap_len, uint64_t column_offset, bool *col_is_null)
+{
+    if (column_offset > (bitmap_len * 8) - 1) {
+        return TRILOGY_PROTOCOL_VIOLATION;
+    }
+
+    column_offset += 2;
+
+    uint64_t byte_offset = column_offset / 8;
+
+    // for the binary protocol result row packet, we need to offset the bit check
+    // by 2
+    *col_is_null = (null_bitmap[byte_offset] & (1 << (column_offset % 8))) != 0;
+
+    return TRILOGY_OK;
+}
+
+int trilogy_parse_stmt_row_packet(const uint8_t *buff, size_t len, trilogy_column_packet_t *columns,
+                                  uint64_t column_count, trilogy_binary_value_t *out_values)
+{
+    int rc;
+
+    trilogy_reader_t reader = TRILOGY_READER(buff, len);
+
+    // skip packet header
+    CHECKED(trilogy_reader_get_uint8(&reader, NULL));
+
+    uint8_t *null_bitmap = NULL;
+    uint64_t bitmap_len = (column_count + 7 + 2) / 8;
+
+    CHECKED(trilogy_reader_get_buffer(&reader, bitmap_len, (const void **)&null_bitmap));
+
+    for (uint64_t i = 0; i < column_count; i++) {
+        CHECKED(is_null(null_bitmap, bitmap_len, i, &out_values[i].is_null));
+        if (out_values[i].is_null) {
+            out_values[i].type = TRILOGY_TYPE_NULL;
+        } else {
+            out_values[i].is_null = false;
+
+            out_values[i].type = columns[i].type;
+
+            switch (columns[i].type) {
+            case TRILOGY_TYPE_STRING:
+            case TRILOGY_TYPE_VARCHAR:
+            case TRILOGY_TYPE_VAR_STRING:
+            case TRILOGY_TYPE_ENUM:
+            case TRILOGY_TYPE_SET:
+            case TRILOGY_TYPE_LONG_BLOB:
+            case TRILOGY_TYPE_MEDIUM_BLOB:
+            case TRILOGY_TYPE_BLOB:
+            case TRILOGY_TYPE_TINY_BLOB:
+            case TRILOGY_TYPE_GEOMETRY:
+            case TRILOGY_TYPE_BIT:
+            case TRILOGY_TYPE_DECIMAL:
+            case TRILOGY_TYPE_NEWDECIMAL:
+            case TRILOGY_TYPE_JSON:
+                CHECKED(trilogy_reader_get_lenenc_buffer(&reader, &out_values[i].as.str.len,
+                                                      (const void **)&out_values[i].as.str.data));
+
+                break;
+            case TRILOGY_TYPE_LONGLONG:
+                CHECKED(trilogy_reader_get_uint64(&reader, &out_values[i].as.uint64));
+
+                break;
+            case TRILOGY_TYPE_DOUBLE:
+                CHECKED(trilogy_reader_get_double(&reader, &out_values[i].as.dbl));
+
+                break;
+            case TRILOGY_TYPE_LONG:
+            case TRILOGY_TYPE_INT24:
+                CHECKED(trilogy_reader_get_uint32(&reader, &out_values[i].as.uint32));
+
+                break;
+            case TRILOGY_TYPE_FLOAT:
+                CHECKED(trilogy_reader_get_float(&reader, &out_values[i].as.flt));
+
+                break;
+            case TRILOGY_TYPE_SHORT:
+                CHECKED(trilogy_reader_get_uint16(&reader, &out_values[i].as.uint16));
+
+                break;
+            case TRILOGY_TYPE_YEAR:
+                CHECKED(trilogy_reader_get_uint16(&reader, &out_values[i].as.date.year));
+
+                break;
+            case TRILOGY_TYPE_TINY:
+                CHECKED(trilogy_reader_get_uint8(&reader, &out_values[i].as.uint8));
+
+                break;
+            case TRILOGY_TYPE_DATE:
+            case TRILOGY_TYPE_DATETIME:
+            case TRILOGY_TYPE_TIMESTAMP: {
+                uint8_t time_len;
+
+                CHECKED(trilogy_reader_get_uint8(&reader, &time_len));
+
+                out_values[i].as.date.year = 0;
+                out_values[i].as.date.month = 0;
+                out_values[i].as.date.day = 0;
+                out_values[i].as.date.time.hour = 0;
+                out_values[i].as.date.time.minute = 0;
+                out_values[i].as.date.time.second = 0;
+                out_values[i].as.date.time.micro_seconds = 0;
+
+                switch (time_len) {
+                case 0:
+                    break;
+                case 4:
+                    CHECKED(trilogy_reader_get_uint16(&reader, &out_values[i].as.date.year));
+                    CHECKED(trilogy_reader_get_uint8(&reader, &out_values[i].as.date.month));
+                    CHECKED(trilogy_reader_get_uint8(&reader, &out_values[i].as.date.day));
+
+                    break;
+                case 7:
+                    CHECKED(trilogy_reader_get_uint16(&reader, &out_values[i].as.date.year));
+                    CHECKED(trilogy_reader_get_uint8(&reader, &out_values[i].as.date.month));
+                    CHECKED(trilogy_reader_get_uint8(&reader, &out_values[i].as.date.day));
+                    CHECKED(trilogy_reader_get_uint8(&reader, &out_values[i].as.date.time.hour));
+                    CHECKED(trilogy_reader_get_uint8(&reader, &out_values[i].as.date.time.minute));
+                    CHECKED(trilogy_reader_get_uint8(&reader, &out_values[i].as.date.time.second));
+
+                    break;
+                case 11:
+                    CHECKED(trilogy_reader_get_uint16(&reader, &out_values[i].as.date.year));
+                    CHECKED(trilogy_reader_get_uint8(&reader, &out_values[i].as.date.month));
+                    CHECKED(trilogy_reader_get_uint8(&reader, &out_values[i].as.date.day));
+                    CHECKED(trilogy_reader_get_uint8(&reader, &out_values[i].as.date.time.hour));
+                    CHECKED(trilogy_reader_get_uint8(&reader, &out_values[i].as.date.time.minute));
+                    CHECKED(trilogy_reader_get_uint8(&reader, &out_values[i].as.date.time.second));
+                    CHECKED(trilogy_reader_get_uint32(&reader, &out_values[i].as.date.time.micro_seconds));
+
+                    break;
+                default:
+                    return TRILOGY_PROTOCOL_VIOLATION;
+                }
+
+                break;
+            }
+            case TRILOGY_TYPE_TIME: {
+                uint8_t time_len;
+
+                CHECKED(trilogy_reader_get_uint8(&reader, &time_len));
+
+                out_values[i].as.date.time.is_negative = false;
+                out_values[i].as.date.time.days = 0;
+                out_values[i].as.date.time.hour = 0;
+                out_values[i].as.date.time.minute = 0;
+                out_values[i].as.date.time.second = 0;
+                out_values[i].as.date.time.micro_seconds = 0;
+
+                switch (time_len) {
+                case 0:
+                    break;
+                case 8: {
+                    uint8_t is_negative;
+
+                    CHECKED(trilogy_reader_get_uint8(&reader, &is_negative));
+
+                    out_values[i].as.date.time.is_negative = is_negative == 1;
+
+                    CHECKED(trilogy_reader_get_uint32(&reader, &out_values[i].as.date.time.days));
+                    CHECKED(trilogy_reader_get_uint8(&reader, &out_values[i].as.date.time.hour));
+                    CHECKED(trilogy_reader_get_uint8(&reader, &out_values[i].as.date.time.minute));
+                    CHECKED(trilogy_reader_get_uint8(&reader, &out_values[i].as.date.time.second));
+                    CHECKED(trilogy_reader_get_uint32(&reader, &out_values[i].as.date.time.micro_seconds));
+
+                    break;
+                }
+                case 12: {
+                    uint8_t is_negative;
+
+                    CHECKED(trilogy_reader_get_uint8(&reader, &is_negative));
+
+                    out_values[i].as.date.time.is_negative = is_negative == 1;
+
+                    CHECKED(trilogy_reader_get_uint32(&reader, &out_values[i].as.date.time.days));
+                    CHECKED(trilogy_reader_get_uint8(&reader, &out_values[i].as.date.time.hour));
+                    CHECKED(trilogy_reader_get_uint8(&reader, &out_values[i].as.date.time.minute));
+                    CHECKED(trilogy_reader_get_uint8(&reader, &out_values[i].as.date.time.second));
+                    CHECKED(trilogy_reader_get_uint32(&reader, &out_values[i].as.date.time.micro_seconds));
+
+                    break;
+                }
+                default:
+                    return TRILOGY_PROTOCOL_VIOLATION;
+                }
+
+                break;
+            }
+            case TRILOGY_TYPE_NULL:
+            default:
+                // we cover TRILOGY_TYPE_NULL here because we should never hit this case
+                // explicitly as it should be covered in the null bitmap
+                return TRILOGY_UNKNOWN_TYPE;
+            }
+        }
+    }
+
+    return trilogy_reader_finish(&reader);
 
 fail:
     return rc;

--- a/src/protocol.c
+++ b/src/protocol.c
@@ -823,9 +823,9 @@ int trilogy_build_stmt_execute_packet(trilogy_builder_t *builder, uint32_t stmt_
             case TRILOGY_TYPE_TIME: {
                 uint8_t field_len = 0;
 
-                if (val.as.date.time.micro_seconds) {
+                if (val.as.time.micro_seconds) {
                     field_len = 12;
-                } else if (val.as.date.time.hour || val.as.date.time.minute || val.as.date.time.second) {
+                } else if (val.as.time.hour || val.as.time.minute || val.as.time.second) {
                     field_len = 8;
                 } else {
                     field_len = 0;
@@ -834,18 +834,18 @@ int trilogy_build_stmt_execute_packet(trilogy_builder_t *builder, uint32_t stmt_
                 CHECKED(trilogy_builder_write_uint8(builder, field_len));
 
                 if (field_len > 0) {
-                    CHECKED(trilogy_builder_write_uint8(builder, val.as.date.time.is_negative));
+                    CHECKED(trilogy_builder_write_uint8(builder, val.as.time.is_negative));
 
-                    CHECKED(trilogy_builder_write_uint32(builder, val.as.date.time.days));
+                    CHECKED(trilogy_builder_write_uint32(builder, val.as.time.days));
 
-                    CHECKED(trilogy_builder_write_uint8(builder, val.as.date.time.hour));
+                    CHECKED(trilogy_builder_write_uint8(builder, val.as.time.hour));
 
-                    CHECKED(trilogy_builder_write_uint8(builder, val.as.date.time.minute));
+                    CHECKED(trilogy_builder_write_uint8(builder, val.as.time.minute));
 
-                    CHECKED(trilogy_builder_write_uint8(builder, val.as.date.time.second));
+                    CHECKED(trilogy_builder_write_uint8(builder, val.as.time.second));
 
                     if (field_len > 8) {
-                        CHECKED(trilogy_builder_write_uint32(builder, val.as.date.time.micro_seconds));
+                        CHECKED(trilogy_builder_write_uint32(builder, val.as.time.micro_seconds));
                     }
                 }
 
@@ -856,9 +856,9 @@ int trilogy_build_stmt_execute_packet(trilogy_builder_t *builder, uint32_t stmt_
             case TRILOGY_TYPE_TIMESTAMP: {
                 uint8_t field_len = 0;
 
-                if (val.as.date.time.micro_seconds) {
+                if (val.as.time.micro_seconds) {
                     field_len = 11;
-                } else if (val.as.date.time.hour || val.as.date.time.minute || val.as.date.time.second) {
+                } else if (val.as.time.hour || val.as.time.minute || val.as.time.second) {
                     field_len = 7;
                 } else if (val.as.date.year || val.as.date.month || val.as.date.day) {
                     field_len = 4;
@@ -876,14 +876,14 @@ int trilogy_build_stmt_execute_packet(trilogy_builder_t *builder, uint32_t stmt_
                     CHECKED(trilogy_builder_write_uint8(builder, val.as.date.day));
 
                     if (field_len > 4) {
-                        CHECKED(trilogy_builder_write_uint8(builder, val.as.date.time.hour));
+                        CHECKED(trilogy_builder_write_uint8(builder, val.as.time.hour));
 
-                        CHECKED(trilogy_builder_write_uint8(builder, val.as.date.time.minute));
+                        CHECKED(trilogy_builder_write_uint8(builder, val.as.time.minute));
 
-                        CHECKED(trilogy_builder_write_uint8(builder, val.as.date.time.second));
+                        CHECKED(trilogy_builder_write_uint8(builder, val.as.time.second));
 
                         if (field_len > 7) {
-                            CHECKED(trilogy_builder_write_uint32(builder, val.as.date.time.micro_seconds));
+                            CHECKED(trilogy_builder_write_uint32(builder, val.as.time.micro_seconds));
                         }
                     }
                 }
@@ -1079,10 +1079,10 @@ int trilogy_parse_stmt_row_packet(const uint8_t *buff, size_t len, trilogy_colum
                 out_values[i].as.date.year = 0;
                 out_values[i].as.date.month = 0;
                 out_values[i].as.date.day = 0;
-                out_values[i].as.date.time.hour = 0;
-                out_values[i].as.date.time.minute = 0;
-                out_values[i].as.date.time.second = 0;
-                out_values[i].as.date.time.micro_seconds = 0;
+                out_values[i].as.time.hour = 0;
+                out_values[i].as.time.minute = 0;
+                out_values[i].as.time.second = 0;
+                out_values[i].as.time.micro_seconds = 0;
 
                 switch (time_len) {
                 case 0:
@@ -1097,19 +1097,19 @@ int trilogy_parse_stmt_row_packet(const uint8_t *buff, size_t len, trilogy_colum
                     CHECKED(trilogy_reader_get_uint16(&reader, &out_values[i].as.date.year));
                     CHECKED(trilogy_reader_get_uint8(&reader, &out_values[i].as.date.month));
                     CHECKED(trilogy_reader_get_uint8(&reader, &out_values[i].as.date.day));
-                    CHECKED(trilogy_reader_get_uint8(&reader, &out_values[i].as.date.time.hour));
-                    CHECKED(trilogy_reader_get_uint8(&reader, &out_values[i].as.date.time.minute));
-                    CHECKED(trilogy_reader_get_uint8(&reader, &out_values[i].as.date.time.second));
+                    CHECKED(trilogy_reader_get_uint8(&reader, &out_values[i].as.time.hour));
+                    CHECKED(trilogy_reader_get_uint8(&reader, &out_values[i].as.time.minute));
+                    CHECKED(trilogy_reader_get_uint8(&reader, &out_values[i].as.time.second));
 
                     break;
                 case 11:
                     CHECKED(trilogy_reader_get_uint16(&reader, &out_values[i].as.date.year));
                     CHECKED(trilogy_reader_get_uint8(&reader, &out_values[i].as.date.month));
                     CHECKED(trilogy_reader_get_uint8(&reader, &out_values[i].as.date.day));
-                    CHECKED(trilogy_reader_get_uint8(&reader, &out_values[i].as.date.time.hour));
-                    CHECKED(trilogy_reader_get_uint8(&reader, &out_values[i].as.date.time.minute));
-                    CHECKED(trilogy_reader_get_uint8(&reader, &out_values[i].as.date.time.second));
-                    CHECKED(trilogy_reader_get_uint32(&reader, &out_values[i].as.date.time.micro_seconds));
+                    CHECKED(trilogy_reader_get_uint8(&reader, &out_values[i].as.time.hour));
+                    CHECKED(trilogy_reader_get_uint8(&reader, &out_values[i].as.time.minute));
+                    CHECKED(trilogy_reader_get_uint8(&reader, &out_values[i].as.time.second));
+                    CHECKED(trilogy_reader_get_uint32(&reader, &out_values[i].as.time.micro_seconds));
 
                     break;
                 default:
@@ -1123,12 +1123,12 @@ int trilogy_parse_stmt_row_packet(const uint8_t *buff, size_t len, trilogy_colum
 
                 CHECKED(trilogy_reader_get_uint8(&reader, &time_len));
 
-                out_values[i].as.date.time.is_negative = false;
-                out_values[i].as.date.time.days = 0;
-                out_values[i].as.date.time.hour = 0;
-                out_values[i].as.date.time.minute = 0;
-                out_values[i].as.date.time.second = 0;
-                out_values[i].as.date.time.micro_seconds = 0;
+                out_values[i].as.time.is_negative = false;
+                out_values[i].as.time.days = 0;
+                out_values[i].as.time.hour = 0;
+                out_values[i].as.time.minute = 0;
+                out_values[i].as.time.second = 0;
+                out_values[i].as.time.micro_seconds = 0;
 
                 switch (time_len) {
                 case 0:
@@ -1138,13 +1138,13 @@ int trilogy_parse_stmt_row_packet(const uint8_t *buff, size_t len, trilogy_colum
 
                     CHECKED(trilogy_reader_get_uint8(&reader, &is_negative));
 
-                    out_values[i].as.date.time.is_negative = is_negative == 1;
+                    out_values[i].as.time.is_negative = is_negative == 1;
 
-                    CHECKED(trilogy_reader_get_uint32(&reader, &out_values[i].as.date.time.days));
-                    CHECKED(trilogy_reader_get_uint8(&reader, &out_values[i].as.date.time.hour));
-                    CHECKED(trilogy_reader_get_uint8(&reader, &out_values[i].as.date.time.minute));
-                    CHECKED(trilogy_reader_get_uint8(&reader, &out_values[i].as.date.time.second));
-                    CHECKED(trilogy_reader_get_uint32(&reader, &out_values[i].as.date.time.micro_seconds));
+                    CHECKED(trilogy_reader_get_uint32(&reader, &out_values[i].as.time.days));
+                    CHECKED(trilogy_reader_get_uint8(&reader, &out_values[i].as.time.hour));
+                    CHECKED(trilogy_reader_get_uint8(&reader, &out_values[i].as.time.minute));
+                    CHECKED(trilogy_reader_get_uint8(&reader, &out_values[i].as.time.second));
+                    CHECKED(trilogy_reader_get_uint32(&reader, &out_values[i].as.time.micro_seconds));
 
                     break;
                 }
@@ -1153,13 +1153,13 @@ int trilogy_parse_stmt_row_packet(const uint8_t *buff, size_t len, trilogy_colum
 
                     CHECKED(trilogy_reader_get_uint8(&reader, &is_negative));
 
-                    out_values[i].as.date.time.is_negative = is_negative == 1;
+                    out_values[i].as.time.is_negative = is_negative == 1;
 
-                    CHECKED(trilogy_reader_get_uint32(&reader, &out_values[i].as.date.time.days));
-                    CHECKED(trilogy_reader_get_uint8(&reader, &out_values[i].as.date.time.hour));
-                    CHECKED(trilogy_reader_get_uint8(&reader, &out_values[i].as.date.time.minute));
-                    CHECKED(trilogy_reader_get_uint8(&reader, &out_values[i].as.date.time.second));
-                    CHECKED(trilogy_reader_get_uint32(&reader, &out_values[i].as.date.time.micro_seconds));
+                    CHECKED(trilogy_reader_get_uint32(&reader, &out_values[i].as.time.days));
+                    CHECKED(trilogy_reader_get_uint8(&reader, &out_values[i].as.time.hour));
+                    CHECKED(trilogy_reader_get_uint8(&reader, &out_values[i].as.time.minute));
+                    CHECKED(trilogy_reader_get_uint8(&reader, &out_values[i].as.time.second));
+                    CHECKED(trilogy_reader_get_uint32(&reader, &out_values[i].as.time.micro_seconds));
 
                     break;
                 }

--- a/src/protocol.c
+++ b/src/protocol.c
@@ -856,9 +856,9 @@ int trilogy_build_stmt_execute_packet(trilogy_builder_t *builder, uint32_t stmt_
             case TRILOGY_TYPE_TIMESTAMP: {
                 uint8_t field_len = 0;
 
-                if (val.as.time.micro_seconds) {
+                if (val.as.date.datetime.micro_seconds) {
                     field_len = 11;
-                } else if (val.as.time.hour || val.as.time.minute || val.as.time.second) {
+                } else if (val.as.date.datetime.hour || val.as.date.datetime.minute || val.as.date.datetime.second) {
                     field_len = 7;
                 } else if (val.as.date.year || val.as.date.month || val.as.date.day) {
                     field_len = 4;
@@ -876,14 +876,14 @@ int trilogy_build_stmt_execute_packet(trilogy_builder_t *builder, uint32_t stmt_
                     CHECKED(trilogy_builder_write_uint8(builder, val.as.date.day));
 
                     if (field_len > 4) {
-                        CHECKED(trilogy_builder_write_uint8(builder, val.as.time.hour));
+                        CHECKED(trilogy_builder_write_uint8(builder, val.as.date.datetime.hour));
 
-                        CHECKED(trilogy_builder_write_uint8(builder, val.as.time.minute));
+                        CHECKED(trilogy_builder_write_uint8(builder, val.as.date.datetime.minute));
 
-                        CHECKED(trilogy_builder_write_uint8(builder, val.as.time.second));
+                        CHECKED(trilogy_builder_write_uint8(builder, val.as.date.datetime.second));
 
                         if (field_len > 7) {
-                            CHECKED(trilogy_builder_write_uint32(builder, val.as.time.micro_seconds));
+                            CHECKED(trilogy_builder_write_uint32(builder, val.as.date.datetime.micro_seconds));
                         }
                     }
                 }
@@ -1079,10 +1079,10 @@ int trilogy_parse_stmt_row_packet(const uint8_t *buff, size_t len, trilogy_colum
                 out_values[i].as.date.year = 0;
                 out_values[i].as.date.month = 0;
                 out_values[i].as.date.day = 0;
-                out_values[i].as.time.hour = 0;
-                out_values[i].as.time.minute = 0;
-                out_values[i].as.time.second = 0;
-                out_values[i].as.time.micro_seconds = 0;
+                out_values[i].as.date.datetime.hour = 0;
+                out_values[i].as.date.datetime.minute = 0;
+                out_values[i].as.date.datetime.second = 0;
+                out_values[i].as.date.datetime.micro_seconds = 0;
 
                 switch (time_len) {
                 case 0:
@@ -1097,19 +1097,19 @@ int trilogy_parse_stmt_row_packet(const uint8_t *buff, size_t len, trilogy_colum
                     CHECKED(trilogy_reader_get_uint16(&reader, &out_values[i].as.date.year));
                     CHECKED(trilogy_reader_get_uint8(&reader, &out_values[i].as.date.month));
                     CHECKED(trilogy_reader_get_uint8(&reader, &out_values[i].as.date.day));
-                    CHECKED(trilogy_reader_get_uint8(&reader, &out_values[i].as.time.hour));
-                    CHECKED(trilogy_reader_get_uint8(&reader, &out_values[i].as.time.minute));
-                    CHECKED(trilogy_reader_get_uint8(&reader, &out_values[i].as.time.second));
+                    CHECKED(trilogy_reader_get_uint8(&reader, &out_values[i].as.date.datetime.hour));
+                    CHECKED(trilogy_reader_get_uint8(&reader, &out_values[i].as.date.datetime.minute));
+                    CHECKED(trilogy_reader_get_uint8(&reader, &out_values[i].as.date.datetime.second));
 
                     break;
                 case 11:
                     CHECKED(trilogy_reader_get_uint16(&reader, &out_values[i].as.date.year));
                     CHECKED(trilogy_reader_get_uint8(&reader, &out_values[i].as.date.month));
                     CHECKED(trilogy_reader_get_uint8(&reader, &out_values[i].as.date.day));
-                    CHECKED(trilogy_reader_get_uint8(&reader, &out_values[i].as.time.hour));
-                    CHECKED(trilogy_reader_get_uint8(&reader, &out_values[i].as.time.minute));
-                    CHECKED(trilogy_reader_get_uint8(&reader, &out_values[i].as.time.second));
-                    CHECKED(trilogy_reader_get_uint32(&reader, &out_values[i].as.time.micro_seconds));
+                    CHECKED(trilogy_reader_get_uint8(&reader, &out_values[i].as.date.datetime.hour));
+                    CHECKED(trilogy_reader_get_uint8(&reader, &out_values[i].as.date.datetime.minute));
+                    CHECKED(trilogy_reader_get_uint8(&reader, &out_values[i].as.date.datetime.second));
+                    CHECKED(trilogy_reader_get_uint32(&reader, &out_values[i].as.date.datetime.micro_seconds));
 
                     break;
                 default:

--- a/src/protocol.c
+++ b/src/protocol.c
@@ -782,7 +782,12 @@ int trilogy_build_stmt_execute_packet(trilogy_builder_t *builder, uint32_t stmt_
 
         for (i = 0; i < num_binds; i++) {
             CHECKED(trilogy_builder_write_uint8(builder, binds[i].type));
-            CHECKED(trilogy_builder_write_uint8(builder, 0x0));
+
+            if (binds[i].is_unsigned) {
+                CHECKED(trilogy_builder_write_uint8(builder, 0x80));
+            } else {
+                CHECKED(trilogy_builder_write_uint8(builder, 0x00));
+            }
         }
 
         for (i = 0; i < num_binds; i++) {
@@ -1011,6 +1016,10 @@ int trilogy_parse_stmt_row_packet(const uint8_t *buff, size_t len, trilogy_colum
             out_values[i].is_null = false;
 
             out_values[i].type = columns[i].type;
+
+            if (columns[i].flags & TRILOGY_COLUMN_FLAG_UNSIGNED) {
+                out_values[i].is_unsigned = true;
+            }
 
             switch (columns[i].type) {
             case TRILOGY_TYPE_STRING:

--- a/src/reader.c
+++ b/src/reader.c
@@ -95,26 +95,14 @@ int trilogy_reader_get_uint64(trilogy_reader_t *reader, uint64_t *out)
     return TRILOGY_OK;
 }
 
-#ifndef TRILOGY_FLOAT_BUF
-#define TRILOGY_FLOAT_BUF
-
-typedef union {
-    float f;
-    uint32_t u;
-} trilogy_float_buf_t;
-
-typedef union {
-    double d;
-    uint64_t u;
-} trilogy_double_buf_t;
-
-#endif
-
 int trilogy_reader_get_float(trilogy_reader_t *reader, float *out)
 {
     CHECK(4);
 
-    trilogy_float_buf_t float_val;
+    union {
+        float f;
+        uint32_t u;
+    } float_val;
 
     int rc = trilogy_reader_get_uint32(reader, &float_val.u);
     if (rc != TRILOGY_OK) {
@@ -130,7 +118,10 @@ int trilogy_reader_get_double(trilogy_reader_t *reader, double *out)
 {
     CHECK(8);
 
-    trilogy_double_buf_t double_val;
+    union {
+        double d;
+        uint64_t u;
+    } double_val;
 
     int rc = trilogy_reader_get_uint64(reader, &double_val.u);
     if (rc != TRILOGY_OK) {

--- a/src/reader.c
+++ b/src/reader.c
@@ -95,6 +95,48 @@ int trilogy_reader_get_uint64(trilogy_reader_t *reader, uint64_t *out)
     return TRILOGY_OK;
 }
 
+typedef union {
+    float f;
+    uint32_t u;
+} trilogy_float_buf_t;
+
+int trilogy_reader_get_float(trilogy_reader_t *reader, float *out)
+{
+    CHECK(4);
+
+    trilogy_float_buf_t float_val;
+
+    int rc = trilogy_reader_get_uint32(reader, &float_val.u);
+    if (rc != TRILOGY_OK) {
+        return rc;
+    }
+
+    *out = float_val.f;
+
+    return TRILOGY_OK;
+}
+
+typedef union {
+    double d;
+    uint64_t u;
+} trilogy_double_buf_t;
+
+int trilogy_reader_get_double(trilogy_reader_t *reader, double *out)
+{
+    CHECK(8);
+
+    trilogy_double_buf_t double_val;
+
+    int rc = trilogy_reader_get_uint64(reader, &double_val.u);
+    if (rc != TRILOGY_OK) {
+        return rc;
+    }
+
+    *out = double_val.d;
+
+    return TRILOGY_OK;
+}
+
 int trilogy_reader_get_lenenc(trilogy_reader_t *reader, uint64_t *out)
 {
     CHECK(1);

--- a/src/reader.c
+++ b/src/reader.c
@@ -95,10 +95,20 @@ int trilogy_reader_get_uint64(trilogy_reader_t *reader, uint64_t *out)
     return TRILOGY_OK;
 }
 
+#ifndef TRILOGY_FLOAT_BUF
+#define TRILOGY_FLOAT_BUF
+
 typedef union {
     float f;
     uint32_t u;
 } trilogy_float_buf_t;
+
+typedef union {
+    double d;
+    uint64_t u;
+} trilogy_double_buf_t;
+
+#endif
 
 int trilogy_reader_get_float(trilogy_reader_t *reader, float *out)
 {
@@ -115,11 +125,6 @@ int trilogy_reader_get_float(trilogy_reader_t *reader, float *out)
 
     return TRILOGY_OK;
 }
-
-typedef union {
-    double d;
-    uint64_t u;
-} trilogy_double_buf_t;
 
 int trilogy_reader_get_double(trilogy_reader_t *reader, double *out)
 {

--- a/test/blocking_test.c
+++ b/test/blocking_test.c
@@ -751,7 +751,7 @@ TEST test_blocking_stmt_execute_year()
 
     connect_conn(&conn);
 
-    const char *query = "SELECT CAST('2023' AS YEAR)";
+    const char *query = "SELECT YEAR('2022-01-31')";
     trilogy_stmt_t stmt;
 
     int err = trilogy_stmt_prepare(&conn, query, strlen(query), &stmt);
@@ -782,7 +782,7 @@ TEST test_blocking_stmt_execute_year()
     err = trilogy_stmt_read_full_row(&conn, &stmt, columns, values);
     ASSERT_OK(err);
 
-    ASSERT_EQ(values[0].as.year, 2023);
+    ASSERT_EQ(values[0].as.year, 2022);
 
     err = trilogy_stmt_read_full_row(&conn, &stmt, columns, values);
     ASSERT_EOF(err);

--- a/test/blocking_test.c
+++ b/test/blocking_test.c
@@ -417,7 +417,13 @@ TEST test_blocking_stmt_execute_float() {
     err = trilogy_stmt_read_full_row(&conn, &stmt, columns, values);
     ASSERT_OK(err);
 
-    ASSERT_EQ(values[0].as.flt, float_val);
+    // With MySQL 5.7, the value is returned from the server as a float.
+    // With MySQL 8, the value is returned from the server as a double.
+    if (columns[0].type == TRILOGY_TYPE_FLOAT) {
+        ASSERT_EQ(values[0].as.flt, float_val);
+    } else if (columns[0].type == TRILOGY_TYPE_DOUBLE) {
+        ASSERT_EQ(values[0].as.dbl, float_val);
+    }
 
     err = trilogy_stmt_read_full_row(&conn, &stmt, columns, values);
     ASSERT_EOF(err);

--- a/test/blocking_test.c
+++ b/test/blocking_test.c
@@ -165,6 +165,150 @@ TEST test_blocking_query_no_rows()
     PASS();
 }
 
+TEST test_blocking_stmt_prepare()
+{
+    trilogy_conn_t conn;
+
+    connect_conn(&conn);
+
+    const char *query = "SELECT ?";
+    trilogy_stmt_t stmt;
+
+    int err = trilogy_stmt_prepare(&conn, query, strlen(query), &stmt);
+    ASSERT_OK(err);
+
+    ASSERT_EQ(1, stmt.parameter_count);
+
+    trilogy_column_packet_t param;
+    err = trilogy_read_full_column(&conn, &param);
+    ASSERT_OK(err);
+
+    ASSERT_EQ(1, stmt.column_count);
+
+    trilogy_column_packet_t column_def;
+    err = trilogy_read_full_column(&conn, &column_def);
+    ASSERT_OK(err);
+
+    trilogy_free(&conn);
+    PASS();
+}
+
+TEST test_blocking_stmt_execute()
+{
+    trilogy_conn_t conn;
+
+    connect_conn(&conn);
+
+    const char *query = "SELECT ?";
+    trilogy_stmt_t stmt;
+
+    int err = trilogy_stmt_prepare(&conn, query, strlen(query), &stmt);
+    ASSERT_OK(err);
+
+    ASSERT_EQ(1, stmt.parameter_count);
+
+    trilogy_column_packet_t param;
+    err = trilogy_read_full_column(&conn, &param);
+    ASSERT_OK(err);
+
+    ASSERT_EQ(1, stmt.column_count);
+
+    trilogy_column_packet_t column_def;
+    err = trilogy_read_full_column(&conn, &column_def);
+    ASSERT_OK(err);
+
+    uint8_t flags = 0x00;
+    const char str[] = {'t', 'e', 's', 't'};
+    size_t len = sizeof(str);
+    trilogy_binary_value_t binds[] = {
+        {.is_null = false, .type = TRILOGY_TYPE_VAR_STRING, .as.str.data = str, .as.str.len = len}};
+
+    uint64_t column_count;
+
+    err = trilogy_stmt_execute(&conn, &stmt, flags, binds, &column_count);
+    ASSERT_OK(err);
+
+    ASSERT_EQ(1, column_count);
+
+    trilogy_column_packet_t columns[1];
+    err = trilogy_read_full_column(&conn, &columns[0]);
+    ASSERT_OK(err);
+
+    trilogy_binary_value_t values[1];
+    err = trilogy_stmt_read_full_row(&conn, &stmt, columns, values);
+    ASSERT_OK(err);
+
+    ASSERT_MEM_EQ(values[0].as.str.data, "test", values[0].as.str.len);
+
+    err = trilogy_stmt_read_full_row(&conn, &stmt, columns, values);
+    ASSERT_EOF(err);
+
+    trilogy_free(&conn);
+    PASS();
+}
+
+TEST test_blocking_stmt_reset()
+{
+    trilogy_conn_t conn;
+
+    connect_conn(&conn);
+
+    const char *query = "SELECT ?";
+    trilogy_stmt_t stmt;
+
+    int err = trilogy_stmt_prepare(&conn, query, strlen(query), &stmt);
+    ASSERT_OK(err);
+
+    ASSERT_EQ(1, stmt.parameter_count);
+
+    trilogy_column_packet_t param;
+    err = trilogy_read_full_column(&conn, &param);
+    ASSERT_OK(err);
+
+    ASSERT_EQ(1, stmt.column_count);
+
+    trilogy_column_packet_t column_def;
+    err = trilogy_read_full_column(&conn, &column_def);
+    ASSERT_OK(err);
+
+    err = trilogy_stmt_reset(&conn, &stmt);
+    ASSERT_OK(err);
+
+    trilogy_free(&conn);
+    PASS();
+}
+
+TEST test_blocking_stmt_close()
+{
+    trilogy_conn_t conn;
+
+    connect_conn(&conn);
+
+    const char *query = "SELECT ?";
+    trilogy_stmt_t stmt;
+
+    int err = trilogy_stmt_prepare(&conn, query, strlen(query), &stmt);
+    ASSERT_OK(err);
+
+    ASSERT_EQ(1, stmt.parameter_count);
+
+    trilogy_column_packet_t param;
+    err = trilogy_read_full_column(&conn, &param);
+    ASSERT_OK(err);
+
+    ASSERT_EQ(1, stmt.column_count);
+
+    trilogy_column_packet_t column_def;
+    err = trilogy_read_full_column(&conn, &column_def);
+    ASSERT_OK(err);
+
+    err = trilogy_stmt_close(&conn, &stmt);
+    ASSERT_OK(err);
+
+    trilogy_free(&conn);
+    PASS();
+}
+
 int blocking_test()
 {
     RUN_TEST(test_blocking_connect);
@@ -174,6 +318,10 @@ int blocking_test()
     RUN_TEST(test_blocking_query);
     RUN_TEST(test_blocking_query_error);
     RUN_TEST(test_blocking_query_no_rows);
+    RUN_TEST(test_blocking_stmt_prepare);
+    RUN_TEST(test_blocking_stmt_execute);
+    RUN_TEST(test_blocking_stmt_reset);
+    RUN_TEST(test_blocking_stmt_close);
 
     return 0;
 }

--- a/test/blocking_test.c
+++ b/test/blocking_test.c
@@ -193,7 +193,7 @@ TEST test_blocking_stmt_prepare()
     PASS();
 }
 
-TEST test_blocking_stmt_execute()
+TEST test_blocking_stmt_execute_str()
 {
     trilogy_conn_t conn;
 
@@ -239,6 +239,184 @@ TEST test_blocking_stmt_execute()
     ASSERT_OK(err);
 
     ASSERT_MEM_EQ(values[0].as.str.data, "test", values[0].as.str.len);
+
+    err = trilogy_stmt_read_full_row(&conn, &stmt, columns, values);
+    ASSERT_EOF(err);
+
+    trilogy_free(&conn);
+    PASS();
+}
+
+TEST test_blocking_stmt_execute_integer()
+{
+    trilogy_conn_t conn;
+
+    connect_conn(&conn);
+
+    const char *query = "SELECT ?";
+    trilogy_stmt_t stmt;
+
+    int err = trilogy_stmt_prepare(&conn, query, strlen(query), &stmt);
+    ASSERT_OK(err);
+
+    ASSERT_EQ(1, stmt.parameter_count);
+
+    trilogy_column_packet_t param;
+    err = trilogy_read_full_column(&conn, &param);
+    ASSERT_OK(err);
+
+    ASSERT_EQ(1, stmt.column_count);
+
+    trilogy_column_packet_t column_def;
+    err = trilogy_read_full_column(&conn, &column_def);
+    ASSERT_OK(err);
+
+    uint8_t flags = 0x00;
+    uint32_t unsigned_val = 1234;
+    trilogy_binary_value_t binds[] = {
+        {.is_null = false, .is_unsigned = true, .type = TRILOGY_TYPE_LONG, .as.uint32 = unsigned_val}};
+
+    uint64_t column_count;
+
+    err = trilogy_stmt_execute(&conn, &stmt, flags, binds, &column_count);
+    ASSERT_OK(err);
+
+    ASSERT_EQ(1, column_count);
+
+    trilogy_column_packet_t columns[1];
+    err = trilogy_read_full_column(&conn, &columns[0]);
+    ASSERT_OK(err);
+
+    trilogy_binary_value_t values[1];
+    err = trilogy_stmt_read_full_row(&conn, &stmt, columns, values);
+    ASSERT_OK(err);
+
+    ASSERT_EQ(values[0].as.uint32, unsigned_val);
+
+    err = trilogy_stmt_read_full_row(&conn, &stmt, columns, values);
+    ASSERT_EOF(err);
+
+    int32_t signed_val = -1234;
+
+    trilogy_binary_value_t signed_binds[] = {
+        {.is_null = false, .is_unsigned = false, .type = TRILOGY_TYPE_LONG, .as.int32 = signed_val}};
+
+    err = trilogy_stmt_execute(&conn, &stmt, flags, signed_binds, &column_count);
+    ASSERT_OK(err);
+
+    ASSERT_EQ(1, column_count);
+
+    err = trilogy_read_full_column(&conn, &columns[0]);
+    ASSERT_OK(err);
+
+    err = trilogy_stmt_read_full_row(&conn, &stmt, columns, values);
+    ASSERT_OK(err);
+
+    ASSERT_EQ(values[0].as.int32, signed_val);
+
+    err = trilogy_stmt_read_full_row(&conn, &stmt, columns, values);
+    ASSERT_EOF(err);
+
+    trilogy_free(&conn);
+    PASS();
+}
+
+TEST test_blocking_stmt_execute_double()
+{
+    trilogy_conn_t conn;
+
+    connect_conn(&conn);
+
+    const char *query = "SELECT ?";
+    trilogy_stmt_t stmt;
+
+    int err = trilogy_stmt_prepare(&conn, query, strlen(query), &stmt);
+    ASSERT_OK(err);
+
+    ASSERT_EQ(1, stmt.parameter_count);
+
+    trilogy_column_packet_t param;
+    err = trilogy_read_full_column(&conn, &param);
+    ASSERT_OK(err);
+
+    ASSERT_EQ(1, stmt.column_count);
+
+    trilogy_column_packet_t column_def;
+    err = trilogy_read_full_column(&conn, &column_def);
+    ASSERT_OK(err);
+
+    uint8_t flags = 0x00;
+    double dbl_val = 1234.5;
+    trilogy_binary_value_t binds[] = {
+        {.is_null = false, .is_unsigned = true, .type = TRILOGY_TYPE_DOUBLE, .as.dbl = dbl_val}};
+
+    uint64_t column_count;
+
+    err = trilogy_stmt_execute(&conn, &stmt, flags, binds, &column_count);
+    ASSERT_OK(err);
+
+    ASSERT_EQ(1, column_count);
+
+    trilogy_column_packet_t columns[1];
+    err = trilogy_read_full_column(&conn, &columns[0]);
+    ASSERT_OK(err);
+
+    trilogy_binary_value_t values[1];
+    err = trilogy_stmt_read_full_row(&conn, &stmt, columns, values);
+    ASSERT_OK(err);
+
+    ASSERT_EQ(values[0].as.dbl, dbl_val);
+
+    err = trilogy_stmt_read_full_row(&conn, &stmt, columns, values);
+    ASSERT_EOF(err);
+
+    trilogy_free(&conn);
+    PASS();
+}
+
+TEST test_blocking_stmt_execute_datetime()
+{
+    trilogy_conn_t conn;
+
+    connect_conn(&conn);
+
+    const char *query = "SELECT CAST('2022-01-31 21:15:45' AS DATETIME)";
+    trilogy_stmt_t stmt;
+
+    int err = trilogy_stmt_prepare(&conn, query, strlen(query), &stmt);
+    ASSERT_OK(err);
+
+    ASSERT_EQ(0, stmt.parameter_count);
+
+    ASSERT_EQ(1, stmt.column_count);
+
+    trilogy_column_packet_t column_def;
+    err = trilogy_read_full_column(&conn, &column_def);
+    ASSERT_OK(err);
+
+    uint8_t flags = 0x00;
+
+    uint64_t column_count;
+
+    err = trilogy_stmt_execute(&conn, &stmt, flags, NULL, &column_count);
+    ASSERT_OK(err);
+
+    ASSERT_EQ(1, column_count);
+
+    trilogy_column_packet_t columns[1];
+    err = trilogy_read_full_column(&conn, &columns[0]);
+    ASSERT_OK(err);
+
+    trilogy_binary_value_t values[1];
+    err = trilogy_stmt_read_full_row(&conn, &stmt, columns, values);
+    ASSERT_OK(err);
+
+    ASSERT_EQ(values[0].as.date.year, 2022);
+    ASSERT_EQ(values[0].as.date.month, 1);
+    ASSERT_EQ(values[0].as.date.day, 31);
+    ASSERT_EQ(values[0].as.date.datetime.hour, 21);
+    ASSERT_EQ(values[0].as.date.datetime.minute, 15);
+    ASSERT_EQ(values[0].as.date.datetime.second, 45);
 
     err = trilogy_stmt_read_full_row(&conn, &stmt, columns, values);
     ASSERT_EOF(err);
@@ -319,7 +497,10 @@ int blocking_test()
     RUN_TEST(test_blocking_query_error);
     RUN_TEST(test_blocking_query_no_rows);
     RUN_TEST(test_blocking_stmt_prepare);
-    RUN_TEST(test_blocking_stmt_execute);
+    RUN_TEST(test_blocking_stmt_execute_str);
+    RUN_TEST(test_blocking_stmt_execute_integer);
+    RUN_TEST(test_blocking_stmt_execute_double);
+    RUN_TEST(test_blocking_stmt_execute_datetime);
     RUN_TEST(test_blocking_stmt_reset);
     RUN_TEST(test_blocking_stmt_close);
 

--- a/test/blocking_test.c
+++ b/test/blocking_test.c
@@ -374,6 +374,278 @@ TEST test_blocking_stmt_execute_double()
     PASS();
 }
 
+TEST test_blocking_stmt_execute_float() {
+    trilogy_conn_t conn;
+
+    connect_conn(&conn);
+
+    const char *query = "SELECT ?";
+    trilogy_stmt_t stmt;
+
+    int err = trilogy_stmt_prepare(&conn, query, strlen(query), &stmt);
+    ASSERT_OK(err);
+
+    ASSERT_EQ(1, stmt.parameter_count);
+
+    trilogy_column_packet_t param;
+    err = trilogy_read_full_column(&conn, &param);
+    ASSERT_OK(err);
+
+    ASSERT_EQ(1, stmt.column_count);
+
+    trilogy_column_packet_t column_def;
+    err = trilogy_read_full_column(&conn, &column_def);
+    ASSERT_OK(err);
+
+    uint8_t flags = 0x00;
+    float float_val = 1234.5f;
+    trilogy_binary_value_t binds[] = {
+        {.is_null = false, .is_unsigned = true, .type = TRILOGY_TYPE_FLOAT, .as.flt = float_val}};
+
+    uint64_t column_count;
+
+    err = trilogy_stmt_execute(&conn, &stmt, flags, binds, &column_count);
+    ASSERT_OK(err);
+
+    ASSERT_EQ(1, column_count);
+
+    trilogy_column_packet_t columns[1];
+    err = trilogy_read_full_column(&conn, &columns[0]);
+    ASSERT_OK(err);
+
+    trilogy_binary_value_t values[1];
+    err = trilogy_stmt_read_full_row(&conn, &stmt, columns, values);
+    ASSERT_OK(err);
+
+    ASSERT_EQ(values[0].as.flt, float_val);
+
+    err = trilogy_stmt_read_full_row(&conn, &stmt, columns, values);
+    ASSERT_EOF(err);
+
+    trilogy_free(&conn);
+    PASS();
+}
+
+TEST test_blocking_stmt_execute_long()
+{
+    trilogy_conn_t conn;
+
+    connect_conn(&conn);
+
+    const char *query = "SELECT ?";
+    trilogy_stmt_t stmt;
+
+    int err = trilogy_stmt_prepare(&conn, query, strlen(query), &stmt);
+    ASSERT_OK(err);
+
+    ASSERT_EQ(1, stmt.parameter_count);
+
+    trilogy_column_packet_t param;
+    err = trilogy_read_full_column(&conn, &param);
+    ASSERT_OK(err);
+
+    ASSERT_EQ(1, stmt.column_count);
+
+    trilogy_column_packet_t column_def;
+    err = trilogy_read_full_column(&conn, &column_def);
+    ASSERT_OK(err);
+
+    uint8_t flags = 0x00;
+    uint64_t unsigned_val = 1234;
+    trilogy_binary_value_t binds[] = {
+        {.is_null = false, .is_unsigned = true, .type = TRILOGY_TYPE_LONGLONG, .as.uint64 = unsigned_val}};
+
+    uint64_t column_count;
+
+    err = trilogy_stmt_execute(&conn, &stmt, flags, binds, &column_count);
+    ASSERT_OK(err);
+
+    ASSERT_EQ(1, column_count);
+
+    trilogy_column_packet_t columns[1];
+    err = trilogy_read_full_column(&conn, &columns[0]);
+    ASSERT_OK(err);
+
+    trilogy_binary_value_t values[1];
+    err = trilogy_stmt_read_full_row(&conn, &stmt, columns, values);
+    ASSERT_OK(err);
+
+    ASSERT_EQ(values[0].as.uint64, unsigned_val);
+
+    err = trilogy_stmt_read_full_row(&conn, &stmt, columns, values);
+    ASSERT_EOF(err);
+
+    int64_t signed_val = -1234;
+
+    trilogy_binary_value_t signed_binds[] = {
+        {.is_null = false, .is_unsigned = false, .type = TRILOGY_TYPE_LONGLONG, .as.int64 = signed_val}};
+
+    err = trilogy_stmt_execute(&conn, &stmt, flags, signed_binds, &column_count);
+    ASSERT_OK(err);
+
+    ASSERT_EQ(1, column_count);
+
+    err = trilogy_read_full_column(&conn, &columns[0]);
+    ASSERT_OK(err);
+
+    err = trilogy_stmt_read_full_row(&conn, &stmt, columns, values);
+    ASSERT_OK(err);
+
+    ASSERT_EQ(values[0].as.int64, signed_val);
+
+    err = trilogy_stmt_read_full_row(&conn, &stmt, columns, values);
+    ASSERT_EOF(err);
+
+    trilogy_free(&conn);
+    PASS();
+}
+
+TEST test_blocking_stmt_execute_short() {
+    trilogy_conn_t conn;
+
+    connect_conn(&conn);
+
+    const char *query = "SELECT ?";
+    trilogy_stmt_t stmt;
+
+    int err = trilogy_stmt_prepare(&conn, query, strlen(query), &stmt);
+    ASSERT_OK(err);
+
+    ASSERT_EQ(1, stmt.parameter_count);
+
+    trilogy_column_packet_t param;
+    err = trilogy_read_full_column(&conn, &param);
+    ASSERT_OK(err);
+
+    ASSERT_EQ(1, stmt.column_count);
+
+    trilogy_column_packet_t column_def;
+    err = trilogy_read_full_column(&conn, &column_def);
+    ASSERT_OK(err);
+
+    uint8_t flags = 0x00;
+    uint16_t unsigned_val = 1234;
+    trilogy_binary_value_t binds[] = {
+        {.is_null = false, .is_unsigned = true, .type = TRILOGY_TYPE_SHORT, .as.uint16 = unsigned_val}};
+
+    uint64_t column_count;
+
+    err = trilogy_stmt_execute(&conn, &stmt, flags, binds, &column_count);
+    ASSERT_OK(err);
+
+    ASSERT_EQ(1, column_count);
+
+    trilogy_column_packet_t columns[1];
+    err = trilogy_read_full_column(&conn, &columns[0]);
+    ASSERT_OK(err);
+
+    trilogy_binary_value_t values[1];
+    err = trilogy_stmt_read_full_row(&conn, &stmt, columns, values);
+    ASSERT_OK(err);
+
+    ASSERT_EQ(values[0].as.uint16, unsigned_val);
+
+    err = trilogy_stmt_read_full_row(&conn, &stmt, columns, values);
+    ASSERT_EOF(err);
+
+    int16_t signed_val = -1234;
+
+    trilogy_binary_value_t signed_binds[] = {
+        {.is_null = false, .is_unsigned = false, .type = TRILOGY_TYPE_SHORT, .as.int16 = signed_val}};
+
+    err = trilogy_stmt_execute(&conn, &stmt, flags, signed_binds, &column_count);
+    ASSERT_OK(err);
+
+    ASSERT_EQ(1, column_count);
+
+    err = trilogy_read_full_column(&conn, &columns[0]);
+    ASSERT_OK(err);
+
+    err = trilogy_stmt_read_full_row(&conn, &stmt, columns, values);
+    ASSERT_OK(err);
+
+    ASSERT_EQ(values[0].as.int16, signed_val);
+
+    err = trilogy_stmt_read_full_row(&conn, &stmt, columns, values);
+    ASSERT_EOF(err);
+
+    trilogy_free(&conn);
+    PASS();
+}
+
+TEST test_blocking_stmt_execute_tiny() {
+    trilogy_conn_t conn;
+
+    connect_conn(&conn);
+
+    const char *query = "SELECT ?";
+    trilogy_stmt_t stmt;
+
+    int err = trilogy_stmt_prepare(&conn, query, strlen(query), &stmt);
+    ASSERT_OK(err);
+
+    ASSERT_EQ(1, stmt.parameter_count);
+
+    trilogy_column_packet_t param;
+    err = trilogy_read_full_column(&conn, &param);
+    ASSERT_OK(err);
+
+    ASSERT_EQ(1, stmt.column_count);
+
+    trilogy_column_packet_t column_def;
+    err = trilogy_read_full_column(&conn, &column_def);
+    ASSERT_OK(err);
+
+    uint8_t flags = 0x00;
+    uint8_t unsigned_val = 123;
+    trilogy_binary_value_t binds[] = {
+        {.is_null = false, .is_unsigned = true, .type = TRILOGY_TYPE_TINY, .as.uint8 = unsigned_val}};
+
+    uint64_t column_count;
+
+    err = trilogy_stmt_execute(&conn, &stmt, flags, binds, &column_count);
+    ASSERT_OK(err);
+
+    ASSERT_EQ(1, column_count);
+
+    trilogy_column_packet_t columns[1];
+    err = trilogy_read_full_column(&conn, &columns[0]);
+    ASSERT_OK(err);
+
+    trilogy_binary_value_t values[1];
+    err = trilogy_stmt_read_full_row(&conn, &stmt, columns, values);
+    ASSERT_OK(err);
+
+    ASSERT_EQ(values[0].as.uint8, unsigned_val);
+
+    err = trilogy_stmt_read_full_row(&conn, &stmt, columns, values);
+    ASSERT_EOF(err);
+
+    int8_t signed_val = -123;
+
+    trilogy_binary_value_t signed_binds[] = {
+        {.is_null = false, .is_unsigned = false, .type = TRILOGY_TYPE_TINY, .as.int8 = signed_val}};
+
+    err = trilogy_stmt_execute(&conn, &stmt, flags, signed_binds, &column_count);
+    ASSERT_OK(err);
+
+    ASSERT_EQ(1, column_count);
+
+    err = trilogy_read_full_column(&conn, &columns[0]);
+    ASSERT_OK(err);
+
+    err = trilogy_stmt_read_full_row(&conn, &stmt, columns, values);
+    ASSERT_OK(err);
+
+    ASSERT_EQ(values[0].as.int8, signed_val);
+
+    err = trilogy_stmt_read_full_row(&conn, &stmt, columns, values);
+    ASSERT_EOF(err);
+
+    trilogy_free(&conn);
+    PASS();
+}
+
 TEST test_blocking_stmt_execute_datetime()
 {
     trilogy_conn_t conn;
@@ -417,6 +689,100 @@ TEST test_blocking_stmt_execute_datetime()
     ASSERT_EQ(values[0].as.date.datetime.hour, 21);
     ASSERT_EQ(values[0].as.date.datetime.minute, 15);
     ASSERT_EQ(values[0].as.date.datetime.second, 45);
+
+    err = trilogy_stmt_read_full_row(&conn, &stmt, columns, values);
+    ASSERT_EOF(err);
+
+    trilogy_free(&conn);
+    PASS();
+}
+
+TEST test_blocking_stmt_execute_time()
+{
+    trilogy_conn_t conn;
+
+    connect_conn(&conn);
+
+    const char *query = "SELECT CAST('21:15:45' AS TIME)";
+    trilogy_stmt_t stmt;
+
+    int err = trilogy_stmt_prepare(&conn, query, strlen(query), &stmt);
+    ASSERT_OK(err);
+
+    ASSERT_EQ(0, stmt.parameter_count);
+
+    ASSERT_EQ(1, stmt.column_count);
+
+    trilogy_column_packet_t column_def;
+    err = trilogy_read_full_column(&conn, &column_def);
+    ASSERT_OK(err);
+
+    uint8_t flags = 0x00;
+
+    uint64_t column_count;
+
+    err = trilogy_stmt_execute(&conn, &stmt, flags, NULL, &column_count);
+    ASSERT_OK(err);
+
+    ASSERT_EQ(1, column_count);
+
+    trilogy_column_packet_t columns[1];
+    err = trilogy_read_full_column(&conn, &columns[0]);
+    ASSERT_OK(err);
+
+    trilogy_binary_value_t values[1];
+    err = trilogy_stmt_read_full_row(&conn, &stmt, columns, values);
+    ASSERT_OK(err);
+
+    ASSERT_EQ(values[0].as.time.hour, 21);
+    ASSERT_EQ(values[0].as.time.minute, 15);
+    ASSERT_EQ(values[0].as.time.second, 45);
+
+    err = trilogy_stmt_read_full_row(&conn, &stmt, columns, values);
+    ASSERT_EOF(err);
+
+    trilogy_free(&conn);
+    PASS();
+}
+
+TEST test_blocking_stmt_execute_year()
+{
+    trilogy_conn_t conn;
+
+    connect_conn(&conn);
+
+    const char *query = "SELECT CAST('2023' AS YEAR)";
+    trilogy_stmt_t stmt;
+
+    int err = trilogy_stmt_prepare(&conn, query, strlen(query), &stmt);
+    ASSERT_OK(err);
+
+    ASSERT_EQ(0, stmt.parameter_count);
+
+    ASSERT_EQ(1, stmt.column_count);
+
+    trilogy_column_packet_t column_def;
+    err = trilogy_read_full_column(&conn, &column_def);
+    ASSERT_OK(err);
+
+    uint8_t flags = 0x00;
+
+    uint64_t column_count;
+
+    err = trilogy_stmt_execute(&conn, &stmt, flags, NULL, &column_count);
+    ASSERT_OK(err);
+
+    ASSERT_EQ(1, column_count);
+
+    trilogy_column_packet_t columns[1];
+    err = trilogy_read_full_column(&conn, &columns[0]);
+    ASSERT_OK(err);
+
+    trilogy_binary_value_t values[1];
+    err = trilogy_stmt_read_full_row(&conn, &stmt, columns, values);
+    ASSERT_OK(err);
+
+    ASSERT_EQ(values[0].as.year, 2023);
 
     err = trilogy_stmt_read_full_row(&conn, &stmt, columns, values);
     ASSERT_EOF(err);
@@ -500,7 +866,13 @@ int blocking_test()
     RUN_TEST(test_blocking_stmt_execute_str);
     RUN_TEST(test_blocking_stmt_execute_integer);
     RUN_TEST(test_blocking_stmt_execute_double);
+    RUN_TEST(test_blocking_stmt_execute_float);
+    RUN_TEST(test_blocking_stmt_execute_long);
+    RUN_TEST(test_blocking_stmt_execute_short);
+    RUN_TEST(test_blocking_stmt_execute_tiny);
     RUN_TEST(test_blocking_stmt_execute_datetime);
+    RUN_TEST(test_blocking_stmt_execute_time);
+    RUN_TEST(test_blocking_stmt_execute_year);
     RUN_TEST(test_blocking_stmt_reset);
     RUN_TEST(test_blocking_stmt_close);
 

--- a/test/client/stmt_close_test.c
+++ b/test/client/stmt_close_test.c
@@ -1,0 +1,163 @@
+#include <errno.h>
+#include <poll.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+
+#include "../test.h"
+
+#include "trilogy/blocking.h"
+#include "trilogy/client.h"
+#include "trilogy/error.h"
+
+#define do_connect(CONN)                                                                                               \
+    do {                                                                                                               \
+        int err = trilogy_init(CONN);                                                                                  \
+        ASSERT_OK(err);                                                                                                \
+        err = trilogy_connect(CONN, get_connopt());                                                                    \
+        ASSERT_OK(err);                                                                                                \
+    } while (0)
+
+TEST test_stmt_close_send()
+{
+    trilogy_conn_t conn;
+
+    do_connect(&conn);
+
+    const char *sql = "SELECT ?";
+    size_t sql_len = strlen(sql);
+
+    int err = trilogy_stmt_prepare_send(&conn, sql, sql_len);
+    while (err == TRILOGY_AGAIN) {
+        err = wait_writable(&conn);
+        ASSERT_OK(err);
+
+        err = trilogy_flush_writes(&conn);
+    }
+    ASSERT_OK(err);
+
+    trilogy_stmt_t stmt;
+
+    err = trilogy_stmt_prepare_recv(&conn, &stmt);
+    while (err == TRILOGY_AGAIN) {
+        err = wait_readable(&conn);
+        ASSERT_OK(err);
+
+        err = trilogy_stmt_prepare_recv(&conn, &stmt);
+    }
+    ASSERT_OK(err);
+
+    ASSERT_EQ(1, stmt.parameter_count);
+
+    trilogy_column_packet_t params[1];
+
+    for (uint64_t i = 0; i < stmt.parameter_count; i++) {
+        trilogy_column_packet_t *param = &params[i];
+
+        err = trilogy_read_full_column(&conn, param);
+
+        if (err < 0) {
+            return err;
+        }
+    }
+
+    ASSERT_EQ(1, stmt.column_count);
+
+    trilogy_column_packet_t column_defs[1];
+
+    for (uint64_t i = 0; i < stmt.column_count; i++) {
+        trilogy_column_packet_t *column = &column_defs[i];
+
+        err = trilogy_read_full_column(&conn, column);
+
+        if (err < 0) {
+            return err;
+        }
+    }
+
+    err = trilogy_stmt_close_send(&conn, &stmt);
+    while (err == TRILOGY_AGAIN) {
+        err = wait_writable(&conn);
+        ASSERT_OK(err);
+
+        err = trilogy_flush_writes(&conn);
+    }
+    ASSERT_OK(err);
+
+    trilogy_free(&conn);
+    PASS();
+}
+
+TEST test_stmt_close_send_closed_socket()
+{
+    trilogy_conn_t conn;
+
+    do_connect(&conn);
+
+    const char *sql = "SELECT ?";
+    size_t sql_len = strlen(sql);
+
+    int err = trilogy_stmt_prepare_send(&conn, sql, sql_len);
+    while (err == TRILOGY_AGAIN) {
+        err = wait_writable(&conn);
+        ASSERT_OK(err);
+
+        err = trilogy_flush_writes(&conn);
+    }
+    ASSERT_OK(err);
+
+    trilogy_stmt_t stmt;
+
+    err = trilogy_stmt_prepare_recv(&conn, &stmt);
+    while (err == TRILOGY_AGAIN) {
+        err = wait_readable(&conn);
+        ASSERT_OK(err);
+
+        err = trilogy_stmt_prepare_recv(&conn, &stmt);
+    }
+    ASSERT_OK(err);
+
+    ASSERT_EQ(1, stmt.parameter_count);
+
+    trilogy_column_packet_t params[1];
+
+    for (uint64_t i = 0; i < stmt.parameter_count; i++) {
+        trilogy_column_packet_t *param = &params[i];
+
+        err = trilogy_read_full_column(&conn, param);
+
+        if (err < 0) {
+            return err;
+        }
+    }
+
+    ASSERT_EQ(1, stmt.column_count);
+
+    trilogy_column_packet_t column_defs[1];
+
+    for (uint64_t i = 0; i < stmt.column_count; i++) {
+        trilogy_column_packet_t *column = &column_defs[i];
+
+        err = trilogy_read_full_column(&conn, column);
+
+        if (err < 0) {
+            return err;
+        }
+    }
+
+    close_socket(&conn);
+
+    err = trilogy_stmt_close_send(&conn, &stmt);
+    ASSERT_ERR(TRILOGY_SYSERR, err);
+
+    trilogy_free(&conn);
+    PASS();
+}
+
+int client_stmt_close_test()
+{
+    RUN_TEST(test_stmt_close_send);
+    RUN_TEST(test_stmt_close_send_closed_socket);
+
+    return 0;
+}

--- a/test/client/stmt_execute_test.c
+++ b/test/client/stmt_execute_test.c
@@ -317,8 +317,6 @@ TEST test_stmt_execute_recv_closed_socket()
         err = trilogy_read_full_column(&conn, param);
 
         if (err < 0) {
-            free(params);
-
             return err;
         }
     }
@@ -333,8 +331,6 @@ TEST test_stmt_execute_recv_closed_socket()
         err = trilogy_read_full_column(&conn, column);
 
         if (err < 0) {
-            free(column_defs);
-
             return err;
         }
     }

--- a/test/client/stmt_execute_test.c
+++ b/test/client/stmt_execute_test.c
@@ -1,0 +1,376 @@
+#include <errno.h>
+#include <poll.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+
+#include "../test.h"
+
+#include "trilogy/blocking.h"
+#include "trilogy/client.h"
+#include "trilogy/error.h"
+
+#define do_connect(CONN)                                                                                               \
+    do {                                                                                                               \
+        int err = trilogy_init(CONN);                                                                                  \
+        ASSERT_OK(err);                                                                                                \
+        err = trilogy_connect(CONN, get_connopt());                                                                    \
+        ASSERT_OK(err);                                                                                                \
+    } while (0)
+
+TEST test_stmt_execute_send()
+{
+    trilogy_conn_t conn;
+
+    do_connect(&conn);
+
+    const char *sql = "SELECT ?";
+    size_t sql_len = strlen(sql);
+
+    int err = trilogy_stmt_prepare_send(&conn, sql, sql_len);
+    while (err == TRILOGY_AGAIN) {
+        err = wait_writable(&conn);
+        ASSERT_OK(err);
+
+        err = trilogy_flush_writes(&conn);
+    }
+    ASSERT_OK(err);
+
+    trilogy_stmt_t stmt;
+
+    err = trilogy_stmt_prepare_recv(&conn, &stmt);
+    while (err == TRILOGY_AGAIN) {
+        err = wait_readable(&conn);
+        ASSERT_OK(err);
+
+        err = trilogy_stmt_prepare_recv(&conn, &stmt);
+    }
+    ASSERT_OK(err);
+
+    ASSERT_EQ(1, stmt.parameter_count);
+
+    trilogy_column_packet_t params[1];
+
+    for (uint64_t i = 0; i < stmt.parameter_count; i++) {
+        trilogy_column_packet_t *param = &params[i];
+
+        err = trilogy_read_full_column(&conn, param);
+
+        if (err < 0) {
+            return err;
+        }
+    }
+
+    ASSERT_EQ(1, stmt.column_count);
+
+    trilogy_column_packet_t column_defs[1];
+
+    for (uint64_t i = 0; i < stmt.column_count; i++) {
+        trilogy_column_packet_t *column = &column_defs[i];
+
+        err = trilogy_read_full_column(&conn, column);
+
+        if (err < 0) {
+            return err;
+        }
+    }
+
+    uint8_t flags = 0x00;
+    const char str[] = {'t','e','s','t'};
+    size_t len = sizeof(str);
+    trilogy_binary_value_t binds[] = {
+        {.is_null = false, .type = TRILOGY_TYPE_VAR_STRING, .as.str.data = str, .as.str.len = len}};
+
+    err = trilogy_stmt_execute_send(&conn, &stmt, flags, binds);
+    while (err == TRILOGY_AGAIN) {
+        err = wait_writable(&conn);
+        ASSERT_OK(err);
+
+        err = trilogy_flush_writes(&conn);
+    }
+    ASSERT_OK(err);
+
+    trilogy_free(&conn);
+    PASS();
+}
+
+TEST test_stmt_execute_send_closed_socket()
+{
+    trilogy_conn_t conn;
+
+    do_connect(&conn);
+
+    const char *sql = "SELECT ?";
+    size_t sql_len = strlen(sql);
+
+    int err = trilogy_stmt_prepare_send(&conn, sql, sql_len);
+    while (err == TRILOGY_AGAIN) {
+        err = wait_writable(&conn);
+        ASSERT_OK(err);
+
+        err = trilogy_flush_writes(&conn);
+    }
+    ASSERT_OK(err);
+
+    trilogy_stmt_t stmt;
+
+    err = trilogy_stmt_prepare_recv(&conn, &stmt);
+    while (err == TRILOGY_AGAIN) {
+        err = wait_readable(&conn);
+        ASSERT_OK(err);
+
+        err = trilogy_stmt_prepare_recv(&conn, &stmt);
+    }
+    ASSERT_OK(err);
+
+    ASSERT_EQ(1, stmt.parameter_count);
+
+    trilogy_column_packet_t params[1];
+
+    for (uint64_t i = 0; i < stmt.parameter_count; i++) {
+        trilogy_column_packet_t *param = &params[i];
+
+        err = trilogy_read_full_column(&conn, param);
+
+        if (err < 0) {
+            return err;
+        }
+    }
+
+    ASSERT_EQ(1, stmt.column_count);
+
+    trilogy_column_packet_t column_defs[1];
+
+    for (uint64_t i = 0; i < stmt.column_count; i++) {
+        trilogy_column_packet_t *column = &column_defs[i];
+
+        err = trilogy_read_full_column(&conn, column);
+
+        if (err < 0) {
+            return err;
+        }
+    }
+
+    close_socket(&conn);
+
+    uint8_t flags = 0x00;
+    const char str[] = {'t', 'e', 's', 't'};
+    size_t len = sizeof(str);
+    trilogy_binary_value_t binds[] = {
+        {.is_null = false, .type = TRILOGY_TYPE_VAR_STRING, .as.str.data = str, .as.str.len = len}};
+
+    err = trilogy_stmt_execute_send(&conn, &stmt, flags, binds);
+    ASSERT_ERR(TRILOGY_SYSERR, err);
+
+    trilogy_free(&conn);
+    PASS();
+}
+
+TEST test_stmt_execute_recv()
+{
+    trilogy_conn_t conn;
+
+    do_connect(&conn);
+
+    const char *sql = "SELECT ?";
+    size_t sql_len = strlen(sql);
+
+    int err = trilogy_stmt_prepare_send(&conn, sql, sql_len);
+    while (err == TRILOGY_AGAIN) {
+        err = wait_writable(&conn);
+        ASSERT_OK(err);
+
+        err = trilogy_flush_writes(&conn);
+    }
+    ASSERT_OK(err);
+
+    trilogy_stmt_t stmt;
+
+    err = trilogy_stmt_prepare_recv(&conn, &stmt);
+    while (err == TRILOGY_AGAIN) {
+        err = wait_readable(&conn);
+        ASSERT_OK(err);
+
+        err = trilogy_stmt_prepare_recv(&conn, &stmt);
+    }
+    ASSERT_OK(err);
+
+    ASSERT_EQ(1, stmt.parameter_count);
+
+    trilogy_column_packet_t params[1];
+
+    for (uint64_t i = 0; i < stmt.parameter_count; i++) {
+        trilogy_column_packet_t *param = &params[i];
+
+        err = trilogy_read_full_column(&conn, param);
+
+        if (err < 0) {
+            return err;
+        }
+    }
+
+    ASSERT_EQ(1, stmt.column_count);
+
+    trilogy_column_packet_t column_defs[1];
+
+    for (uint64_t i = 0; i < stmt.column_count; i++) {
+        trilogy_column_packet_t *column = &column_defs[i];
+
+        err = trilogy_read_full_column(&conn, column);
+
+        if (err < 0) {
+            return err;
+        }
+    }
+
+    uint8_t flags = 0x00;
+    const char str[] = {'t', 'e', 's', 't'};
+    size_t len = sizeof(str);
+    trilogy_binary_value_t binds[] = {
+        {.is_null = false, .type = TRILOGY_TYPE_VAR_STRING, .as.str.data = str, .as.str.len = len}};
+
+    err = trilogy_stmt_execute_send(&conn, &stmt, flags, binds);
+    while (err == TRILOGY_AGAIN) {
+        err = wait_writable(&conn);
+        ASSERT_OK(err);
+
+        err = trilogy_flush_writes(&conn);
+    }
+    ASSERT_OK(err);
+
+    uint64_t column_count;
+
+    err = trilogy_stmt_execute_recv(&conn, &column_count);
+    while (err == TRILOGY_AGAIN) {
+        err = wait_readable(&conn);
+        ASSERT_OK(err);
+
+        err = trilogy_stmt_execute_recv(&conn, &column_count);
+    }
+    ASSERT_OK(err);
+
+    ASSERT_EQ(1, column_count);
+
+    trilogy_column_packet_t columns[1];
+
+    for (uint64_t i = 0; i < column_count; i++) {
+        trilogy_column_packet_t *column = &columns[i];
+
+        err = trilogy_read_full_column(&conn, column);
+
+        if (err < 0) {
+            return err;
+        }
+    }
+
+    trilogy_binary_value_t values[1];
+
+    err = trilogy_stmt_read_full_row(&conn, &stmt, columns, values);
+    ASSERT_OK(err);
+
+    ASSERT_MEM_EQ(values[0].as.str.data, "test", values[0].as.str.len);
+
+    err = trilogy_stmt_read_full_row(&conn, &stmt, columns, values);
+    ASSERT_EOF(err);
+
+    trilogy_free(&conn);
+    PASS();
+}
+
+TEST test_stmt_execute_recv_closed_socket()
+{
+
+    trilogy_conn_t conn;
+
+    do_connect(&conn);
+
+    const char *sql = "SELECT ?";
+    size_t sql_len = strlen(sql);
+
+    int err = trilogy_stmt_prepare_send(&conn, sql, sql_len);
+    while (err == TRILOGY_AGAIN) {
+        err = wait_writable(&conn);
+        ASSERT_OK(err);
+
+        err = trilogy_flush_writes(&conn);
+    }
+    ASSERT_OK(err);
+
+    trilogy_stmt_t stmt;
+
+    err = trilogy_stmt_prepare_recv(&conn, &stmt);
+    while (err == TRILOGY_AGAIN) {
+        err = wait_readable(&conn);
+        ASSERT_OK(err);
+
+        err = trilogy_stmt_prepare_recv(&conn, &stmt);
+    }
+    ASSERT_OK(err);
+
+    ASSERT_EQ(1, stmt.parameter_count);
+
+    trilogy_column_packet_t params[1];
+
+    for (uint64_t i = 0; i < stmt.parameter_count; i++) {
+        trilogy_column_packet_t *param = &params[i];
+
+        err = trilogy_read_full_column(&conn, param);
+
+        if (err < 0) {
+            free(params);
+
+            return err;
+        }
+    }
+
+    ASSERT_EQ(1, stmt.column_count);
+
+    trilogy_column_packet_t column_defs[1];
+
+    for (uint64_t i = 0; i < stmt.column_count; i++) {
+        trilogy_column_packet_t *column = &column_defs[i];
+
+        err = trilogy_read_full_column(&conn, column);
+
+        if (err < 0) {
+            free(column_defs);
+
+            return err;
+        }
+    }
+
+    uint8_t flags = 0x00;
+    const char str[] = {'t', 'e', 's', 't'};
+    size_t len = sizeof(str);
+    trilogy_binary_value_t binds[] = {
+        {.is_null = false, .type = TRILOGY_TYPE_VAR_STRING, .as.str.data = str, .as.str.len = len}};
+
+    err = trilogy_stmt_execute_send(&conn, &stmt, flags, binds);
+    while (err == TRILOGY_AGAIN) {
+        err = wait_writable(&conn);
+        ASSERT_OK(err);
+
+        err = trilogy_flush_writes(&conn);
+    }
+    ASSERT_OK(err);
+
+    close_socket(&conn);
+
+    uint64_t column_count;
+
+    err = trilogy_stmt_execute_recv(&conn, &column_count);
+    ASSERT_ERR(TRILOGY_SYSERR, err);
+
+    trilogy_free(&conn);
+    PASS();
+}
+
+int client_stmt_execute_test()
+{
+    RUN_TEST(test_stmt_execute_send);
+    RUN_TEST(test_stmt_execute_send_closed_socket);
+    RUN_TEST(test_stmt_execute_recv);
+    RUN_TEST(test_stmt_execute_recv_closed_socket);
+
+    return 0;
+}

--- a/test/client/stmt_prepare_test.c
+++ b/test/client/stmt_prepare_test.c
@@ -1,0 +1,159 @@
+#include <errno.h>
+#include <poll.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+
+#include "../test.h"
+
+#include "trilogy/blocking.h"
+#include "trilogy/client.h"
+#include "trilogy/error.h"
+
+#define do_connect(CONN)                                                                                               \
+    do {                                                                                                               \
+        int err = trilogy_init(CONN);                                                                                  \
+        ASSERT_OK(err);                                                                                                \
+        err = trilogy_connect(CONN, get_connopt());                                                                    \
+        ASSERT_OK(err);                                                                                                \
+    } while (0)
+
+TEST test_stmt_prepare_send()
+{
+    trilogy_conn_t conn;
+
+    do_connect(&conn);
+
+    const char *sql = "SELECT ?";
+    size_t sql_len = strlen(sql);
+
+    int err = trilogy_stmt_prepare_send(&conn, sql, sql_len);
+    while (err == TRILOGY_AGAIN) {
+        err = wait_writable(&conn);
+        ASSERT_OK(err);
+
+        err = trilogy_flush_writes(&conn);
+    }
+    ASSERT_OK(err);
+
+    trilogy_free(&conn);
+    PASS();
+}
+
+TEST test_stmt_prepare_send_closed_socket()
+{
+    trilogy_conn_t conn;
+
+    do_connect(&conn);
+
+    close_socket(&conn);
+
+    const char *sql = "SELECT ?";
+    size_t sql_len = strlen(sql);
+
+    int err = trilogy_stmt_prepare_send(&conn, sql, sql_len);
+    ASSERT_ERR(TRILOGY_SYSERR, err);
+
+    trilogy_free(&conn);
+    PASS();
+}
+
+TEST test_stmt_prepare_recv()
+{
+    trilogy_conn_t conn;
+
+    do_connect(&conn);
+
+    const char *sql = "SELECT ?";
+    size_t sql_len = strlen(sql);
+
+    int err = trilogy_stmt_prepare_send(&conn, sql, sql_len);
+    while (err == TRILOGY_AGAIN) {
+        err = wait_writable(&conn);
+        ASSERT_OK(err);
+
+        err = trilogy_flush_writes(&conn);
+    }
+    ASSERT_OK(err);
+
+    trilogy_stmt_t stmt;
+
+    err = trilogy_stmt_prepare_recv(&conn, &stmt);
+    while (err == TRILOGY_AGAIN) {
+        err = wait_readable(&conn);
+        ASSERT_OK(err);
+
+        err = trilogy_stmt_prepare_recv(&conn, &stmt);
+    }
+    ASSERT_OK(err);
+
+    ASSERT_EQ(1, stmt.parameter_count);
+
+    trilogy_column_packet_t params[1];
+
+    for (uint64_t i = 0; i < stmt.parameter_count; i++) {
+        trilogy_column_packet_t *param = &params[i];
+
+        err = trilogy_read_full_column(&conn, param);
+
+        if (err < 0) {
+            return err;
+        }
+    }
+
+    ASSERT_EQ(1, stmt.column_count);
+
+    trilogy_column_packet_t column_defs[1];
+
+    for (uint64_t i = 0; i < stmt.column_count; i++) {
+        trilogy_column_packet_t *column = &column_defs[i];
+
+        err = trilogy_read_full_column(&conn, column);
+
+        if (err < 0) {
+            return err;
+        }
+    }
+
+    trilogy_free(&conn);
+    PASS();
+}
+
+TEST test_stmt_prepare_recv_closed_socket()
+{
+    trilogy_conn_t conn;
+
+    do_connect(&conn);
+
+    const char *sql = "SELECT ?";
+    size_t sql_len = strlen(sql);
+
+    int err = trilogy_stmt_prepare_send(&conn, sql, sql_len);
+    while (err == TRILOGY_AGAIN) {
+        err = wait_writable(&conn);
+        ASSERT_OK(err);
+
+        err = trilogy_flush_writes(&conn);
+    }
+    ASSERT_OK(err);
+
+    close_socket(&conn);
+
+    trilogy_stmt_t stmt;
+
+    err = trilogy_stmt_prepare_recv(&conn, &stmt);
+    ASSERT_ERR(TRILOGY_SYSERR, err);
+
+    trilogy_free(&conn);
+    PASS();
+}
+
+int client_stmt_prepare_test()
+{
+    RUN_TEST(test_stmt_prepare_send);
+    RUN_TEST(test_stmt_prepare_send_closed_socket);
+    RUN_TEST(test_stmt_prepare_recv);
+    RUN_TEST(test_stmt_prepare_recv_closed_socket);
+
+    return 0;
+}

--- a/test/client/stmt_reset_test.c
+++ b/test/client/stmt_reset_test.c
@@ -1,0 +1,319 @@
+#include <errno.h>
+#include <poll.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+
+#include "../test.h"
+
+#include "trilogy/blocking.h"
+#include "trilogy/client.h"
+#include "trilogy/error.h"
+
+#define do_connect(CONN)                                                                                               \
+    do {                                                                                                               \
+        int err = trilogy_init(CONN);                                                                                  \
+        ASSERT_OK(err);                                                                                                \
+        err = trilogy_connect(CONN, get_connopt());                                                                    \
+        ASSERT_OK(err);                                                                                                \
+    } while (0)
+
+TEST test_stmt_reset_send()
+{
+    trilogy_conn_t conn;
+
+    do_connect(&conn);
+
+    const char *sql = "SELECT ?";
+    size_t sql_len = strlen(sql);
+
+    int err = trilogy_stmt_prepare_send(&conn, sql, sql_len);
+    while (err == TRILOGY_AGAIN) {
+        err = wait_writable(&conn);
+        ASSERT_OK(err);
+
+        err = trilogy_flush_writes(&conn);
+    }
+    ASSERT_OK(err);
+
+    trilogy_stmt_t stmt;
+
+    err = trilogy_stmt_prepare_recv(&conn, &stmt);
+    while (err == TRILOGY_AGAIN) {
+        err = wait_readable(&conn);
+        ASSERT_OK(err);
+
+        err = trilogy_stmt_prepare_recv(&conn, &stmt);
+    }
+    ASSERT_OK(err);
+
+    ASSERT_EQ(1, stmt.parameter_count);
+
+    trilogy_column_packet_t params[1];
+
+    for (uint64_t i = 0; i < stmt.parameter_count; i++) {
+        trilogy_column_packet_t *param = &params[i];
+
+        err = trilogy_read_full_column(&conn, param);
+
+        if (err < 0) {
+            return err;
+        }
+    }
+
+    ASSERT_EQ(1, stmt.column_count);
+
+    trilogy_column_packet_t column_defs[1];
+
+    for (uint64_t i = 0; i < stmt.column_count; i++) {
+        trilogy_column_packet_t *column = &column_defs[i];
+
+        err = trilogy_read_full_column(&conn, column);
+
+        if (err < 0) {
+            return err;
+        }
+    }
+
+    err = trilogy_stmt_reset_send(&conn, &stmt);
+    while (err == TRILOGY_AGAIN) {
+        err = wait_writable(&conn);
+        ASSERT_OK(err);
+
+        err = trilogy_flush_writes(&conn);
+    }
+    ASSERT_OK(err);
+
+    trilogy_free(&conn);
+    PASS();
+}
+
+TEST test_stmt_reset_send_closed_socket()
+{
+    trilogy_conn_t conn;
+
+    do_connect(&conn);
+
+    const char *sql = "SELECT ?";
+    size_t sql_len = strlen(sql);
+
+    int err = trilogy_stmt_prepare_send(&conn, sql, sql_len);
+    while (err == TRILOGY_AGAIN) {
+        err = wait_writable(&conn);
+        ASSERT_OK(err);
+
+        err = trilogy_flush_writes(&conn);
+    }
+    ASSERT_OK(err);
+
+    trilogy_stmt_t stmt;
+
+    err = trilogy_stmt_prepare_recv(&conn, &stmt);
+    while (err == TRILOGY_AGAIN) {
+        err = wait_readable(&conn);
+        ASSERT_OK(err);
+
+        err = trilogy_stmt_prepare_recv(&conn, &stmt);
+    }
+    ASSERT_OK(err);
+
+    ASSERT_EQ(1, stmt.parameter_count);
+
+    trilogy_column_packet_t params[1];
+
+    for (uint64_t i = 0; i < stmt.parameter_count; i++) {
+        trilogy_column_packet_t *param = &params[i];
+
+        err = trilogy_read_full_column(&conn, param);
+
+        if (err < 0) {
+            return err;
+        }
+    }
+
+    ASSERT_EQ(1, stmt.column_count);
+
+    trilogy_column_packet_t column_defs[1];
+
+    for (uint64_t i = 0; i < stmt.column_count; i++) {
+        trilogy_column_packet_t *column = &column_defs[i];
+
+        err = trilogy_read_full_column(&conn, column);
+
+        if (err < 0) {
+            return err;
+        }
+    }
+
+    close_socket(&conn);
+
+    err = trilogy_stmt_reset_send(&conn, &stmt);
+    ASSERT_ERR(TRILOGY_SYSERR, err);
+
+    trilogy_free(&conn);
+    PASS();
+}
+
+TEST test_stmt_reset_recv()
+{
+    trilogy_conn_t conn;
+
+    do_connect(&conn);
+
+    const char *sql = "SELECT ?";
+    size_t sql_len = strlen(sql);
+
+    int err = trilogy_stmt_prepare_send(&conn, sql, sql_len);
+    while (err == TRILOGY_AGAIN) {
+        err = wait_writable(&conn);
+        ASSERT_OK(err);
+
+        err = trilogy_flush_writes(&conn);
+    }
+    ASSERT_OK(err);
+
+    trilogy_stmt_t stmt;
+
+    err = trilogy_stmt_prepare_recv(&conn, &stmt);
+    while (err == TRILOGY_AGAIN) {
+        err = wait_readable(&conn);
+        ASSERT_OK(err);
+
+        err = trilogy_stmt_prepare_recv(&conn, &stmt);
+    }
+    ASSERT_OK(err);
+
+    ASSERT_EQ(1, stmt.parameter_count);
+
+    trilogy_column_packet_t params[1];
+
+    for (uint64_t i = 0; i < stmt.parameter_count; i++) {
+        trilogy_column_packet_t *param = &params[i];
+
+        err = trilogy_read_full_column(&conn, param);
+
+        if (err < 0) {
+            return err;
+        }
+    }
+
+    ASSERT_EQ(1, stmt.column_count);
+
+    trilogy_column_packet_t column_defs[1];
+
+    for (uint64_t i = 0; i < stmt.column_count; i++) {
+        trilogy_column_packet_t *column = &column_defs[i];
+
+        err = trilogy_read_full_column(&conn, column);
+
+        if (err < 0) {
+            return err;
+        }
+    }
+
+    err = trilogy_stmt_reset_send(&conn, &stmt);
+    while (err == TRILOGY_AGAIN) {
+        err = wait_writable(&conn);
+        ASSERT_OK(err);
+
+        err = trilogy_flush_writes(&conn);
+    }
+    ASSERT_OK(err);
+
+    err = trilogy_stmt_reset_recv(&conn);
+    while (err == TRILOGY_AGAIN) {
+        err = wait_readable(&conn);
+        ASSERT_OK(err);
+
+        err = trilogy_stmt_reset_recv(&conn);
+    }
+    ASSERT_OK(err);
+
+    trilogy_free(&conn);
+    PASS();
+}
+
+TEST test_stmt_reset_recv_closed_socket()
+{
+    trilogy_conn_t conn;
+
+    do_connect(&conn);
+
+    const char *sql = "SELECT ?";
+    size_t sql_len = strlen(sql);
+
+    int err = trilogy_stmt_prepare_send(&conn, sql, sql_len);
+    while (err == TRILOGY_AGAIN) {
+        err = wait_writable(&conn);
+        ASSERT_OK(err);
+
+        err = trilogy_flush_writes(&conn);
+    }
+    ASSERT_OK(err);
+
+    trilogy_stmt_t stmt;
+
+    err = trilogy_stmt_prepare_recv(&conn, &stmt);
+    while (err == TRILOGY_AGAIN) {
+        err = wait_readable(&conn);
+        ASSERT_OK(err);
+
+        err = trilogy_stmt_prepare_recv(&conn, &stmt);
+    }
+    ASSERT_OK(err);
+
+    ASSERT_EQ(1, stmt.parameter_count);
+
+    trilogy_column_packet_t params[1];
+
+    for (uint64_t i = 0; i < stmt.parameter_count; i++) {
+        trilogy_column_packet_t *param = &params[i];
+
+        err = trilogy_read_full_column(&conn, param);
+
+        if (err < 0) {
+            return err;
+        }
+    }
+
+    ASSERT_EQ(1, stmt.column_count);
+
+    trilogy_column_packet_t column_defs[1];
+
+    for (uint64_t i = 0; i < stmt.column_count; i++) {
+        trilogy_column_packet_t *column = &column_defs[i];
+
+        err = trilogy_read_full_column(&conn, column);
+
+        if (err < 0) {
+            return err;
+        }
+    }
+
+    err = trilogy_stmt_reset_send(&conn, &stmt);
+    while (err == TRILOGY_AGAIN) {
+        err = wait_writable(&conn);
+        ASSERT_OK(err);
+
+        err = trilogy_flush_writes(&conn);
+    }
+    ASSERT_OK(err);
+
+    close_socket(&conn);
+
+    err = trilogy_stmt_reset_recv(&conn);
+    ASSERT_ERR(TRILOGY_SYSERR, err);
+
+    trilogy_free(&conn);
+    PASS();
+}
+
+int client_stmt_reset_test()
+{
+    RUN_TEST(test_stmt_reset_send);
+    RUN_TEST(test_stmt_reset_send_closed_socket);
+    RUN_TEST(test_stmt_reset_recv);
+    RUN_TEST(test_stmt_reset_recv_closed_socket);
+
+    return 0;
+}

--- a/test/protocol/building/stmt_bind_data_packet_test.c
+++ b/test/protocol/building/stmt_bind_data_packet_test.c
@@ -1,0 +1,43 @@
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+
+#include "../../test.h"
+
+#include "trilogy/error.h"
+#include "trilogy/protocol.h"
+
+TEST test_stmt_bind_data_packet()
+{
+    trilogy_builder_t builder;
+    trilogy_buffer_t buff;
+
+    int err = trilogy_buffer_init(&buff, 1);
+    ASSERT_OK(err);
+
+    err = trilogy_builder_init(&builder, &buff, 0);
+    ASSERT_OK(err);
+
+    uint32_t stmt_id = 1;
+    uint32_t param_id = 2;
+    uint8_t data[] = {'d', 'a', 't', 'a'};
+    size_t data_len = sizeof(data);
+
+    err = trilogy_build_stmt_bind_data_packet(&builder, stmt_id, param_id, data, data_len);
+    ASSERT_OK(err);
+
+    static const uint8_t expected[] = {0x0b, 0x00, 0x00, 0x00, 0x18, 0x01, 0x00, 0x00, 0x00, 0x02, 0x00, 'd', 'a',
+                                       't', 'a'};
+
+    ASSERT_MEM_EQ(buff.buff, expected, buff.len);
+
+    trilogy_buffer_free(&buff);
+    PASS();
+}
+
+int stmt_bind_data_packet_test()
+{
+    RUN_TEST(test_stmt_bind_data_packet);
+
+    return 0;
+}

--- a/test/protocol/building/stmt_close_packet_test.c
+++ b/test/protocol/building/stmt_close_packet_test.c
@@ -1,0 +1,39 @@
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+
+#include "../../test.h"
+
+#include "trilogy/error.h"
+#include "trilogy/protocol.h"
+
+TEST test_stmt_close_packet()
+{
+    trilogy_builder_t builder;
+    trilogy_buffer_t buff;
+
+    int err = trilogy_buffer_init(&buff, 1);
+    ASSERT_OK(err);
+
+    err = trilogy_builder_init(&builder, &buff, 0);
+    ASSERT_OK(err);
+
+    uint32_t stmt_id = 1;
+
+    err = trilogy_build_stmt_close_packet(&builder, stmt_id);
+    ASSERT_OK(err);
+
+    static const uint8_t expected[] = {0x05, 0x00, 0x00, 0x00, 0x19, 0x01, 0x00, 0x00, 0x00};
+
+    ASSERT_MEM_EQ(buff.buff, expected, buff.len);
+
+    trilogy_buffer_free(&buff);
+    PASS();
+}
+
+int stmt_close_packet_test()
+{
+    RUN_TEST(test_stmt_close_packet);
+
+    return 0;
+}

--- a/test/protocol/building/stmt_execute_packet_test.c
+++ b/test/protocol/building/stmt_execute_packet_test.c
@@ -1,0 +1,43 @@
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+
+#include "../../test.h"
+
+#include "trilogy/error.h"
+#include "trilogy/protocol.h"
+
+TEST test_stmt_execute_packet()
+{
+    trilogy_builder_t builder;
+    trilogy_buffer_t buff;
+
+    int err = trilogy_buffer_init(&buff, 1);
+    ASSERT_OK(err);
+
+    err = trilogy_builder_init(&builder, &buff, 0);
+    ASSERT_OK(err);
+
+    uint32_t stmt_id = 1;
+    uint8_t flags = 1;
+    trilogy_binary_value_t binds[] = {{.is_null = false, .type = TRILOGY_TYPE_LONG, .as.uint32 = 15}};
+    uint16_t num_binds = 1;
+
+    err = trilogy_build_stmt_execute_packet(&builder, stmt_id, flags, binds, num_binds);
+    ASSERT_OK(err);
+
+    static const uint8_t expected[] = {0x12, 0x00, 0x00, 0x00, 0x17, 0x01, 0x00, 0x00, 0x00, 0x01, 0x01, 0x00, 0x00,
+                                       0x00, 0x00, 0x01, 0x03, 0x00, 0x0f, 0x00, 0x00, 0x00};
+
+    ASSERT_MEM_EQ(buff.buff, expected, buff.len);
+
+    trilogy_buffer_free(&buff);
+    PASS();
+}
+
+int stmt_execute_packet_test()
+{
+    RUN_TEST(test_stmt_execute_packet);
+
+    return 0;
+}

--- a/test/protocol/building/stmt_prepare_packet_test.c
+++ b/test/protocol/building/stmt_prepare_packet_test.c
@@ -1,0 +1,40 @@
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+
+#include "../../test.h"
+
+#include "trilogy/error.h"
+#include "trilogy/protocol.h"
+
+TEST test_stmt_prepare_packet()
+{
+    trilogy_builder_t builder;
+    trilogy_buffer_t buff;
+
+    int err = trilogy_buffer_init(&buff, 1);
+    ASSERT_OK(err);
+
+    err = trilogy_builder_init(&builder, &buff, 0);
+    ASSERT_OK(err);
+
+    const char *sql = "SELECT ?";
+    size_t sql_len = strlen(sql);
+
+    err = trilogy_build_stmt_prepare_packet(&builder, sql, sql_len);
+    ASSERT_OK(err);
+
+    static const uint8_t expected[] = {0x09, 0x00, 0x00, 0x00, 0x16, 'S', 'E', 'L', 'E', 'C', 'T', ' ', '?'};
+
+    ASSERT_MEM_EQ(buff.buff, expected, buff.len);
+
+    trilogy_buffer_free(&buff);
+    PASS();
+}
+
+int stmt_prepare_packet_test()
+{
+    RUN_TEST(test_stmt_prepare_packet);
+
+    return 0;
+}

--- a/test/protocol/building/stmt_reset_packet_test.c
+++ b/test/protocol/building/stmt_reset_packet_test.c
@@ -1,0 +1,39 @@
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+
+#include "../../test.h"
+
+#include "trilogy/error.h"
+#include "trilogy/protocol.h"
+
+TEST test_stmt_reset_packet()
+{
+    trilogy_builder_t builder;
+    trilogy_buffer_t buff;
+
+    int err = trilogy_buffer_init(&buff, 1);
+    ASSERT_OK(err);
+
+    err = trilogy_builder_init(&builder, &buff, 0);
+    ASSERT_OK(err);
+
+    uint32_t stmt_id = 1;
+
+    err = trilogy_build_stmt_reset_packet(&builder, stmt_id);
+    ASSERT_OK(err);
+
+    static const uint8_t expected[] = {0x05, 0x00, 0x00, 0x00, 0x1a, 0x01, 0x00, 0x00, 0x00};
+
+    ASSERT_MEM_EQ(buff.buff, expected, buff.len);
+
+    trilogy_buffer_free(&buff);
+    PASS();
+}
+
+int stmt_reset_packet_test()
+{
+    RUN_TEST(test_stmt_reset_packet);
+
+    return 0;
+}

--- a/test/runner.c
+++ b/test/runner.c
@@ -33,12 +33,21 @@ const trilogy_sockopt_t *get_connopt(void) { return &connopt; }
     SUITE(build_quit_packet_test)                                                                                      \
     SUITE(build_set_option_packet_test)                                                                                \
     SUITE(build_query_packet_test)                                                                                     \
+    SUITE(stmt_prepare_packet_test)                                                                                    \
+    SUITE(stmt_bind_data_packet_test)                                                                                  \
+    SUITE(stmt_execute_packet_test)                                                                                    \
+    SUITE(stmt_reset_packet_test)                                                                                      \
+    SUITE(stmt_close_packet_test)                                                                                      \
     SUITE(client_connect_test)                                                                                         \
     SUITE(client_escape_test)                                                                                          \
     SUITE(client_auth_test)                                                                                            \
     SUITE(client_change_db_test)                                                                                       \
     SUITE(client_set_option_test)                                                                                      \
-    SUITE(client_ping_test)
+    SUITE(client_ping_test)                                                                                            \
+    SUITE(client_stmt_prepare_test)                                                                                    \
+    SUITE(client_stmt_execute_test)                                                                                    \
+    SUITE(client_stmt_reset_test)                                                                                      \
+    SUITE(client_stmt_close_test)                                                                                      \
 
 #define XX(name) extern int name();
 ALL_SUITES(XX)

--- a/test/test.h
+++ b/test/test.h
@@ -8,6 +8,7 @@
 
 #define ASSERT_ERR(EXP, GOT) ASSERT_ENUM_EQ((EXP), (GOT), trilogy_error)
 #define ASSERT_OK(GOT) ASSERT_ERR(TRILOGY_OK, (GOT))
+#define ASSERT_EOF(GOT) ASSERT_ERR(TRILOGY_EOF, (GOT))
 
 /* Helpers */
 


### PR DESCRIPTION
As the title says, this adds support for the binary protocol, which is used by prepared statements.

There's still a little bit to do here, though mainly just wrapping up docs and some cleanup and adding a few more tests. But I wanted to get this open for review sooner than later.

I figured wrapping this with the Ruby gem/extension could happen in a separate pull request, but if it makes sense to just go ahead and add here let me know.

Some of the things I'd like to wrap up before calling this done:

- [x] Finish up writing client API docs
- [x] Finish up writing blocking API docs
- [x] Add tests for the blocking API
- [x] Fix null bitmap builder
- [x] Add more tests for edge cases
- [x] Document `trilogy_binary_value_t`, describing which C types map to which MySQL column types.

So happy to see this project finally made open source.

Thank you!