### PR TITLE
caching_sha returns auth_more_data

### DIFF
--- a/inc/trilogy/protocol.h
+++ b/inc/trilogy/protocol.h
@@ -367,6 +367,7 @@ typedef enum {
 // Typical response packet types
 typedef enum {
     TRILOGY_PACKET_OK = 0x0,
+    TRILOGY_PACKET_AUTH_MORE_DATA = 0x01,
     TRILOGY_PACKET_EOF = 0xfe,
     TRILOGY_PACKET_ERR = 0xff,
     TRILOGY_PACKET_UNKNOWN

--- a/src/client.c
+++ b/src/client.c
@@ -418,6 +418,10 @@ int trilogy_auth_recv(trilogy_conn_t *conn, trilogy_handshake_t *handshake)
         trilogy_auth_clear_password(conn);
         return read_ok_packet(conn);
 
+    case TRILOGY_PACKET_AUTH_MORE_DATA:
+       trilogy_auth_clear_password(conn);
+       return read_packet(conn);
+
     case TRILOGY_PACKET_ERR:
         trilogy_auth_clear_password(conn);
         return read_err_packet(conn);


### PR DESCRIPTION

The caching_sha2_password authentication sends auth_more_data, the data doesn't seem to be that useful, its just the current authentication plugin but for other authentication schemes it might include more useful information.

This seems to fix issue #26 

@composerinteralia - I believe this fixes your broken test. From the documentation it seems only mysql_native_password returns ok, the other non challenge-response auth plugin schemes return auth more data.

See https://dev.mysql.com/doc/internals/en/connection-phase-packets.html#packet-Protocol::AuthMoreData

Ideally, this should capture the data payload but for now seems to pass tests.