### PR TITLE
Just use raw close() for discard

### DIFF
--- a/contrib/ruby/test/client_test.rb
+++ b/contrib/ruby/test/client_test.rb
@@ -903,6 +903,18 @@ class ClientTest < TrilogyTest
     assert_match "TRILOGY_CLOSED_CONNECTION", error.message
   end
 
+  def test_discard_closes_connection
+    client = new_tcp_client
+
+    assert_equal [1], client.query("SELECT 1").to_a.first
+
+    client.discard!
+
+    assert_raises Trilogy::ConnectionClosed do
+      client.query("SELECT 1")
+    end
+  end
+
   def test_discard_doesnt_terminate_parent_connection
     skip("Fork isn't supported on this platform") unless Process.respond_to?(:fork)
 

--- a/inc/trilogy/socket.h
+++ b/inc/trilogy/socket.h
@@ -76,6 +76,7 @@ typedef struct trilogy_sock_t {
     int (*wait_cb)(struct trilogy_sock_t *self, trilogy_wait_t wait);
     int (*shutdown_cb)(struct trilogy_sock_t *self);
     int (*close_cb)(struct trilogy_sock_t *self);
+    int (*discard_cb)(struct trilogy_sock_t *self);
     int (*fd_cb)(struct trilogy_sock_t *self);
 
     trilogy_sockopt_t opts;
@@ -102,6 +103,7 @@ static inline int trilogy_sock_wait_write(trilogy_sock_t *sock) { return sock->w
 static inline int trilogy_sock_shutdown(trilogy_sock_t *sock) { return sock->shutdown_cb(sock); }
 
 static inline int trilogy_sock_close(trilogy_sock_t *sock) { return sock->close_cb(sock); }
+static inline int trilogy_sock_discard(trilogy_sock_t *sock) { return sock->discard_cb(sock); }
 
 static inline int trilogy_sock_fd(trilogy_sock_t *sock) { return sock->fd_cb(sock); }
 

--- a/src/client.c
+++ b/src/client.c
@@ -768,6 +768,7 @@ int trilogy_discard(trilogy_conn_t *conn)
 {
     int rc = trilogy_sock_discard(conn->socket);
     if (rc == TRILOGY_OK) {
+        conn->socket = NULL;
         trilogy_free(conn);
     }
     return rc;


### PR DESCRIPTION
Follow up to #65 cc @casperisfine

Previously we were doing a dance with file descriptors in order to replace the connection's fd with one open to `/dev/null`. Instead we should be able to just `close()` the fd so long as we don't perform any writes on it.
