### PR TITLE
 validate max packet size

### DIFF
--- a/contrib/ruby/ext/trilogy-ruby/cext.c
+++ b/contrib/ruby/ext/trilogy-ruby/cext.c
@@ -771,11 +771,12 @@ static VALUE read_query_response(VALUE vargs)
 }
 
 static void validate_query_size(VALUE self, VALUE query, ID id_max_allowed_packet) {
-    char *c_query = StringValueCStr(query);
     VALUE max_allowed_packet = rb_ivar_get(self, id_max_allowed_packet);
+    char *c_query = StringValueCStr(query);
+    unsigned long c_query_size = strlen(c_query);
 
-    if (max_allowed_packet != Qnil && strlen(c_query) >= NUM2ULONG(max_allowed_packet)) {
-        rb_raise(Trilogy_QueryError, "Query is too big %lu vs %lu. Consider increasing max_allowed_packet.", strlen(c_query), NUM2ULONG(max_allowed_packet));
+    if (max_allowed_packet != Qnil && c_query_size >= NUM2ULONG(max_allowed_packet)) {
+        rb_raise(Trilogy_QueryError, "Query is too big %lu vs %lu. Consider increasing max_allowed_packet.", c_query_size, NUM2ULONG(max_allowed_packet));
     }
 }
 

--- a/contrib/ruby/ext/trilogy-ruby/cext.c
+++ b/contrib/ruby/ext/trilogy-ruby/cext.c
@@ -771,10 +771,11 @@ static VALUE read_query_response(VALUE vargs)
 }
 
 static void validate_query_length(VALUE self, VALUE query, ID id_max_allowed_packet) {
+    char *c_query = StringValueCStr(query);
     VALUE max_allowed_packet = rb_ivar_get(self, id_max_allowed_packet);
 
-    if (max_allowed_packet != Qnil && strlen(query) >= NUM2LONG(max_allowed_packet)) {
-        rb_raise(Trilogy_QueryError, "Query is too big %d vs %d. Consider increasing max_allowed_packet.", strlen(query), NUM2LONG(max_allowed_packet));
+    if (max_allowed_packet != Qnil && strlen(c_query) >= NUM2ULONG(max_allowed_packet)) {
+        rb_raise(Trilogy_QueryError, "Query is too big %lu vs %lu. Consider increasing max_allowed_packet.", strlen(c_query), NUM2ULONG(max_allowed_packet));
     }
 }
 
@@ -837,7 +838,7 @@ static VALUE rb_trilogy_query(VALUE self, VALUE query)
     StringValue(query);
     query = rb_str_export_to_enc(query, rb_to_encoding(ctx->encoding));
 
-    validate_query_length(self, StringValueCStr(query), id_max_allowed_packet);
+    validate_query_length(self, query, id_max_allowed_packet);
 
     int rc = trilogy_query_send(&ctx->conn, RSTRING_PTR(query), RSTRING_LEN(query));
 

--- a/contrib/ruby/ext/trilogy-ruby/cext.c
+++ b/contrib/ruby/ext/trilogy-ruby/cext.c
@@ -770,7 +770,7 @@ static VALUE read_query_response(VALUE vargs)
     return result;
 }
 
-static void validate_query_length(VALUE self, VALUE query, ID id_max_allowed_packet) {
+static void validate_query_size(VALUE self, VALUE query, ID id_max_allowed_packet) {
     char *c_query = StringValueCStr(query);
     VALUE max_allowed_packet = rb_ivar_get(self, id_max_allowed_packet);
 
@@ -838,7 +838,7 @@ static VALUE rb_trilogy_query(VALUE self, VALUE query)
     StringValue(query);
     query = rb_str_export_to_enc(query, rb_to_encoding(ctx->encoding));
 
-    validate_query_length(self, query, id_max_allowed_packet);
+    validate_query_size(self, query, id_max_allowed_packet);
 
     int rc = trilogy_query_send(&ctx->conn, RSTRING_PTR(query), RSTRING_LEN(query));
 

--- a/contrib/ruby/lib/trilogy.rb
+++ b/contrib/ruby/lib/trilogy.rb
@@ -196,6 +196,10 @@ class Trilogy
     @connected_host ||= query_with_flags("select @@hostname", query_flags | QUERY_FLAGS_FLATTEN_ROWS).rows.first
   end
 
+  def max_allowed_packet
+    @max_allowed_packet ||= query_with_flags("select @@max_allowed_packet", query_flags | QUERY_FLAGS_FLATTEN_ROWS).rows.first
+  end
+
   def query_with_flags(sql, flags)
     old_flags = query_flags
     self.query_flags = flags

--- a/contrib/ruby/lib/trilogy.rb
+++ b/contrib/ruby/lib/trilogy.rb
@@ -172,6 +172,7 @@ class Trilogy
     encoding = Encoding.find(rb_encoding)
     charset = charset_for_mysql_encoding(mysql_encoding)
     _initialize(encoding, charset, **options)
+    self.max_allowed_packet = options[:max_allowed_packet] || query_with_flags("select @@max_allowed_packet", query_flags | QUERY_FLAGS_FLATTEN_ROWS).rows.first
   end
 
   def connection_options
@@ -194,10 +195,6 @@ class Trilogy
 
   def connected_host
     @connected_host ||= query_with_flags("select @@hostname", query_flags | QUERY_FLAGS_FLATTEN_ROWS).rows.first
-  end
-
-  def max_allowed_packet
-    @max_allowed_packet ||= query_with_flags("select @@max_allowed_packet", query_flags | QUERY_FLAGS_FLATTEN_ROWS).rows.first
   end
 
   def query_with_flags(sql, flags)

--- a/contrib/ruby/test/client_test.rb
+++ b/contrib/ruby/test/client_test.rb
@@ -772,9 +772,11 @@ class ClientTest < TrilogyTest
     assert result
     assert_equal 2, client.last_insert_id
 
-    assert_raises Trilogy::QueryError do
+    exception = assert_raises Trilogy::QueryError do
         client.query "INSERT INTO trilogy_test (blob_test) VALUES ('#{"x" * (4 * 1024 * 1024)}')"
     end
+
+    assert_equal exception.message, "Query is too big 4194352 vs #{4 * 1024 * 1024}. Consider increasing max_allowed_packet."
   ensure
     ensure_closed client
   end

--- a/contrib/ruby/test/client_test.rb
+++ b/contrib/ruby/test/client_test.rb
@@ -740,6 +740,14 @@ class ClientTest < TrilogyTest
     ensure_closed client
   end
 
+  def test_trilogy_max_allowed_packet
+    set_max_allowed_packet(8 * 1024 * 1024)
+
+    client = new_tcp_client
+
+    assert_equal 8 * 1024 * 1024, client.max_allowed_packet
+  end
+
   def test_packet_size
     set_max_allowed_packet(32 * 1024 * 1024)
 


### PR DESCRIPTION
This PR achieves the same goal as https://github.com/rails/rails/pull/48226 intended to but it's done in the client layer.

### Motivation:
Trilogy doesn't do anything to protect against sending queries bigger than the max packet size. Depending on timing and query size, sending a giant query (the default max is 64MB…) could result in either Trilogy::Error: trilogy_query_send: TRILOGY_CLOSED_CONNECTION, Errno::ECONNRESET: Connection reset by peer - trilogy_query_send, or Trilogy::DatabaseError: trilogy_query_recv: 1153 Got a packet bigger than 'max_allowed_packet' bytes.


### Details
This PR just shifts the error to the client side so it can be raised without attempting to sent the query, which used to result in aborting the connection.

It will also improve visibility for this kind of error. Before, we weren't always getting the corresponding error message because sometimes the connection was aborted before we received it from the server.

---
merge after https://github.com/github/trilogy/pull/78