### PR TITLE
fix ci

### DIFF
--- a/Dockerfile.test.stretch
+++ b/Dockerfile.test.stretch
@@ -2,6 +2,7 @@
 FROM debian:stretch
 LABEL maintainer="github@github.com"
 
+RUN echo "deb http://archive.debian.org/debian stretch main contrib non-free" > /etc/apt/sources.list
 RUN apt-get update -qq && DEBIAN_FRONTEND=noninteractive apt-get install --no-install-recommends -y build-essential libssl-dev default-libmysqlclient-dev clang valgrind netcat ruby ruby-dev ruby-bundler
 
 WORKDIR /app

--- a/Dockerfile.test.stretch
+++ b/Dockerfile.test.stretch
@@ -2,7 +2,11 @@
 FROM debian:stretch
 LABEL maintainer="github@github.com"
 
-RUN echo "deb http://archive.debian.org/debian stretch main contrib non-free" > /etc/apt/sources.list
+
+RUN sed -i s/deb.debian.org/archive.debian.org/g /etc/apt/sources.list
+RUN sed -i 's|security.debian.org|archive.debian.org|g' /etc/apt/sources.list
+RUN sed -i '/stretch-updates/d' /etc/apt/sources.list
+
 RUN apt-get update -qq && DEBIAN_FRONTEND=noninteractive apt-get install --no-install-recommends -y build-essential libssl-dev default-libmysqlclient-dev clang valgrind netcat ruby ruby-dev ruby-bundler
 
 WORKDIR /app


### PR DESCRIPTION
stretch was removed from the main mirror cuz it's deprecated

not sure if we wanna keep it in the ci but fixing it wasn't too hard so I guess it's worth keeping it for a bit longer?