### PR TITLE
validate max_allowed_packet on the client side

### DIFF
--- a/contrib/ruby/ext/trilogy-ruby/cext.c
+++ b/contrib/ruby/ext/trilogy-ruby/cext.c
@@ -27,7 +27,7 @@ static ID id_socket, id_host, id_port, id_username, id_password, id_found_rows, 
     id_ivar_affected_rows, id_ivar_fields, id_ivar_last_insert_id, id_ivar_rows, id_ivar_query_time, id_password,
     id_database, id_ssl_ca, id_ssl_capath, id_ssl_cert, id_ssl_cipher, id_ssl_crl, id_ssl_crlpath, id_ssl_key,
     id_ssl_mode, id_tls_ciphersuites, id_tls_min_version, id_tls_max_version, id_multi_statement, id_multi_result,
-    id_from_code, id_from_errno, id_connection_options;
+    id_from_code, id_from_errno, id_connection_options, id_max_allowed_packet;
 
 struct trilogy_ctx {
     trilogy_conn_t conn;
@@ -137,6 +137,10 @@ static void handle_trilogy_error(struct trilogy_ctx *ctx, int rc, const char *ms
 
     case TRILOGY_DNS_ERR: {
         rb_raise(Trilogy_BaseConnectionError, "%" PRIsVALUE ": TRILOGY_DNS_ERROR", rbmsg);
+    }
+
+    case TRILOGY_QUERY_TOO_LONG: {
+        rb_raise(Trilogy_QueryError, "%" PRIsVALUE ": TRILOGY_QUERY_TOO_LONG", rbmsg);
     }
 
     default:
@@ -413,6 +417,11 @@ static VALUE rb_trilogy_initialize(VALUE self, VALUE encoding, VALUE charset, VA
     if ((val = rb_hash_lookup(opts, ID2SYM(id_keepalive_interval))) != Qnil) {
         Check_Type(val, T_FIXNUM);
         connopt.keepalive_interval = NUM2USHORT(val);
+    }
+
+    if ((val = rb_hash_lookup(opts, ID2SYM(id_max_allowed_packet))) != Qnil) {
+        Check_Type(val, T_FIXNUM);
+        connopt.max_allowed_packet = NUM2UINT(val);
     }
 
     if ((val = rb_hash_lookup(opts, ID2SYM(id_host))) != Qnil) {
@@ -1114,6 +1123,7 @@ RUBY_FUNC_EXPORTED void Init_cext()
     id_connect_timeout = rb_intern("connect_timeout");
     id_read_timeout = rb_intern("read_timeout");
     id_write_timeout = rb_intern("write_timeout");
+    id_max_allowed_packet = rb_intern("max_allowed_packet");
     id_keepalive_enabled = rb_intern("keepalive_enabled");
     id_keepalive_idle = rb_intern("keepalive_idle");
     id_keepalive_count = rb_intern("keepalive_count");

--- a/contrib/ruby/test/client_test.rb
+++ b/contrib/ruby/test/client_test.rb
@@ -752,10 +752,35 @@ class ClientTest < TrilogyTest
     ensure_closed client
   end
 
-  def test_packet_size
-    set_max_allowed_packet(32 * 1024 * 1024)
+  def test_packet_size_lower_than_trilogy_max_packet_len
+    set_max_allowed_packet(4 * 1024 * 1024) # TRILOGY_MAX_PACKET_LEN is 16MB
 
-    client = new_tcp_client
+    client = new_tcp_client(max_allowed_packet: 4 * 1024 * 1024)
+
+    create_test_table(client)
+    client.query "TRUNCATE trilogy_test"
+
+    result = client.query "INSERT INTO trilogy_test (blob_test) VALUES ('#{"x" * (1 * 1024 * 1024)}')"
+    assert result
+    assert_equal 1, client.last_insert_id
+
+    result = client.query "INSERT INTO trilogy_test (blob_test) VALUES ('#{"x" * (2 * 1024 * 1024)}')"
+    assert result
+    assert_equal 2, client.last_insert_id
+
+    exception = assert_raises Trilogy::QueryError do
+        client.query "INSERT INTO trilogy_test (blob_test) VALUES ('#{"x" * (4 * 1024 * 1024)}')"
+    end
+
+    assert_equal exception.message, "trilogy_query_send: TRILOGY_QUERY_TOO_LONG"
+  ensure
+    ensure_closed client
+  end
+
+  def test_packet_size_greater_than_trilogy_max_packet_len
+    set_max_allowed_packet(32 * 1024 * 1024) # TRILOGY_MAX_PACKET_LEN is 16MB
+
+    client = new_tcp_client(max_allowed_packet: 32 * 1024 * 1024)
 
     create_test_table(client)
     client.query "TRUNCATE trilogy_test"
@@ -767,6 +792,12 @@ class ClientTest < TrilogyTest
     result = client.query "INSERT INTO trilogy_test (blob_test) VALUES ('#{"x" * (31 * 1024 * 1024)}')"
     assert result
     assert_equal 2, client.last_insert_id
+
+    exception = assert_raises Trilogy::QueryError do
+        client.query "INSERT INTO trilogy_test (blob_test) VALUES ('#{"x" * (32 * 1024 * 1024)}')"
+    end
+
+    assert_equal exception.message, "trilogy_query_send: TRILOGY_QUERY_TOO_LONG"
   ensure
     ensure_closed client
   end

--- a/inc/trilogy/error.h
+++ b/inc/trilogy/error.h
@@ -21,7 +21,8 @@
     XX(TRILOGY_OPENSSL_ERR, -16) /* check ERR_get_error() */                                                           \
     XX(TRILOGY_UNSUPPORTED, -17)                                                                                       \
     XX(TRILOGY_DNS_ERR, -18)                                                                                           \
-    XX(TRILOGY_AUTH_SWITCH, -19)
+    XX(TRILOGY_AUTH_SWITCH, -19)                                                                                       \
+    XX(TRILOGY_QUERY_TOO_LONG, -20)
 
 enum {
 #define XX(name, code) name = code,

--- a/inc/trilogy/socket.h
+++ b/inc/trilogy/socket.h
@@ -66,6 +66,8 @@ typedef struct {
     uint16_t keepalive_count;
     uint16_t keepalive_interval;
 
+    uint32_t max_allowed_packet;
+
     TRILOGY_CAPABILITIES_t flags;
 } trilogy_sockopt_t;
 

--- a/src/client.c
+++ b/src/client.c
@@ -526,8 +526,11 @@ int trilogy_ping_recv(trilogy_conn_t *conn) { return read_generic_response(conn)
 
 int trilogy_query_send(trilogy_conn_t *conn, const char *query, size_t query_len)
 {
-    int err = 0;
+    if (conn->socket->opts.max_allowed_packet != 0 && query_len > conn->socket->opts.max_allowed_packet - 2) {
+        return TRILOGY_QUERY_TOO_LONG;
+    }
 
+    int err = 0;
     trilogy_builder_t builder;
     err = begin_command_phase(&builder, conn, 0);
     if (err < 0) {

--- a/src/client.c
+++ b/src/client.c
@@ -526,6 +526,7 @@ int trilogy_ping_recv(trilogy_conn_t *conn) { return read_generic_response(conn)
 
 int trilogy_query_send(trilogy_conn_t *conn, const char *query, size_t query_len)
 {
+    // we have allow for 2 extra bytes due to the mysql protocol overhead; null byte + command byte(?)
     if (conn->socket->opts.max_allowed_packet != 0 && query_len > conn->socket->opts.max_allowed_packet - 2) {
         return TRILOGY_QUERY_TOO_LONG;
     }


### PR DESCRIPTION
This PR achieves the same goal as https://github.com/rails/rails/pull/48226 and a better version of https://github.com/github/trilogy/pull/74  intended to but it's done in the client layer.

### Motivation:
Trilogy doesn't do anything to protect against sending queries bigger than the max packet size. Depending on timing and query size, sending a giant query (the default max is 64MB…) could result in either Trilogy::Error: trilogy_query_send: TRILOGY_CLOSED_CONNECTION, Errno::ECONNRESET: Connection reset by peer - trilogy_query_send, or Trilogy::DatabaseError: trilogy_query_recv: 1153 Got a packet bigger than 'max_allowed_packet' bytes.


### Details
This PR just shifts the error to the client side so it can be raised without attempting to sent the query, which used to result in aborting the connection.

It will also improve visibility for this kind of error. Before, we weren't always getting the corresponding error message because sometimes the connection was aborted before we received it from the server.

---
merge after https://github.com/github/trilogy/pull/78