### PR TITLE
add default values to ci build

### DIFF
--- a/script/cibuild
+++ b/script/cibuild
@@ -43,6 +43,10 @@ trap cleanup EXIT
 
 export CI_MODE=true
 
+if [ -z "$MYSQL_VERSION" ]; then export MYSQL_VERSION=8 ; fi
+if [ -z "$DISTRIBUTION" ];  then export DISTRIBUTION=debian:buster ; fi
+if [ -z "$RUBY_VERSION" ];  then export RUBY_VERSION=3.2 ; fi
+
 DISTRIBUTION_SLUG="$(echo "$DISTRIBUTION" | awk '{ gsub(":", "_") ; print $0 }')"
 export DISTRIBUTION_SLUG
 


### PR DESCRIPTION
In the CI those values are provided by the workflow yml but since we recommend that script as a way of running the tests locally in the contribution guide it should probably work out of the box. 