### PR TITLE
Avoid unnecessary splat in initialize

### DIFF
--- a/contrib/ruby/lib/trilogy.rb
+++ b/contrib/ruby/lib/trilogy.rb
@@ -12,7 +12,7 @@ class Trilogy
     encoding = Trilogy::Encoding.find(mysql_encoding)
     charset = Trilogy::Encoding.charset(mysql_encoding)
 
-    _initialize(encoding, charset, **options)
+    _initialize(encoding, charset, options)
   end
 
   def connection_options


### PR DESCRIPTION
The splat here isn't necessary, and ends up creating an extra hash along the way.

Removing the splat also gets `Trilogy.new` with no arguments working again, which can me handy for local development.