### PR TITLE
Don't call SSL_shutdown if the connection has not been fully established

### DIFF
--- a/src/socket.c
+++ b/src/socket.c
@@ -356,7 +356,9 @@ static int _cb_ssl_close(trilogy_sock_t *_sock)
 {
     struct trilogy_sock *sock = (struct trilogy_sock *)_sock;
     if (sock->ssl != NULL) {
-        SSL_shutdown(sock->ssl);
+        if (SSL_in_init(sock->ssl) == 0) {
+            SSL_shutdown(sock->ssl);
+        }
         SSL_free(sock->ssl);
         sock->ssl = NULL;
     }


### PR DESCRIPTION
During network problems we have seen a uptick in `Trilogy::SSLError: trilogy_query_recv: SSL Error: shutdown while in init` errors.

It seems like a solution is to ensure that the shutdown only happens after the connection has been fully established: https://github.com/openssl/openssl/issues/710