### PR TITLE
Fix casting of the time type

### DIFF
--- a/contrib/ruby/ext/trilogy-ruby/cast.c
+++ b/contrib/ruby/ext/trilogy-ruby/cast.c
@@ -233,10 +233,6 @@ rb_trilogy_cast_value(const trilogy_value_t *value, const struct column_info *co
                 return Qnil;
             }
 
-            if (hour == 0 && min == 0 && sec == 0) {
-                return Qnil;
-            }
-
             // pad out msec_char with zeroes at the end as it could be at any
             // level of precision
             for (size_t i = strlen(msec_char); i < sizeof(msec_char) - 1; i++) {

--- a/contrib/ruby/test/cast_test.rb
+++ b/contrib/ruby/test/cast_test.rb
@@ -254,6 +254,23 @@ class CastTest < TrilogyTest
     assert_kind_of Time, results[0][0]
   end
 
+  def test_time_zero
+    time = Time.utc(2000, 1, 1, 0, 0, 0)
+
+    @client.query(<<-SQL)
+      INSERT INTO trilogy_test (time_test)
+      VALUES ("#{time.strftime("%H:%M:%S")}")
+    SQL
+
+    results = @client.query(<<-SQL).to_a
+      SELECT time_test FROM trilogy_test
+    SQL
+
+    assert_equal [[time]], results
+
+    assert_kind_of Time, results[0][0]
+  end
+
   def test_timestamp_cast_defaults_to_utc
     @client.query(<<-SQL)
       INSERT INTO trilogy_test (null_test)


### PR DESCRIPTION
A time of 00:00:00 is perfectly valid, so we should not cast that to a nil. That results in incorrect values.