### PR TITLE
Handle EADDRNOTAVAIL as a BaseConnectionError instead of SyscallError

### DIFF
--- a/contrib/ruby/ext/trilogy-ruby/cext.c
+++ b/contrib/ruby/ext/trilogy-ruby/cext.c
@@ -96,6 +96,8 @@ static void trilogy_syserr_fail_str(int e, VALUE msg)
         rb_raise(Trilogy_ConnectionRefusedError, "%" PRIsVALUE, msg);
     } else if (e == ECONNRESET) {
         rb_raise(Trilogy_ConnectionResetError, "%" PRIsVALUE, msg);
+    } else if (e == EADDRNOTAVAIL) {
+        rb_raise(Trilogy_BaseConnectionError, "%" PRIsVALUE ": TRILOGY_DNS_ERROR", msg);
     } else {
         VALUE exc = rb_funcall(Trilogy_SyscallError, id_from_errno, 2, INT2NUM(e), msg);
         rb_exc_raise(exc);


### PR DESCRIPTION
instead of letting EADDRNOTAVAIL be handled as a generic SyscallError convert it to a BaseConnectionError instead, in this case we treat it as a a TRILOGY_DNS_ERROR so that the activerecord adapters handle it as a DBConnectionError.

fixes https://github.com/trilogy-libraries/activerecord-trilogy-adapter/issues/52