### PR TITLE
Cast port to intrger in connection options

### DIFF
--- a/contrib/ruby/lib/trilogy.rb
+++ b/contrib/ruby/lib/trilogy.rb
@@ -8,6 +8,7 @@ require "trilogy/encoding"
 
 class Trilogy
   def initialize(options = {})
+    options[:port] = options[:port].to_i if options.key?(:port)
     mysql_encoding = options[:encoding] || "utf8mb4"
     encoding = Trilogy::Encoding.find(mysql_encoding)
     charset = Trilogy::Encoding.charset(mysql_encoding)

--- a/contrib/ruby/test/client_test.rb
+++ b/contrib/ruby/test/client_test.rb
@@ -30,12 +30,6 @@ class ClientTest < TrilogyTest
     ensure_closed client
   end
 
-  def test_trilogy_connect_tcp_fixnum_port
-    assert_raises TypeError do
-      new_tcp_client port: "13306"
-    end
-  end
-
   def test_trilogy_connect_tcp_to_wrong_port
     e = assert_raises Trilogy::ConnectionError do
       new_tcp_client port: 13307
@@ -1056,5 +1050,18 @@ class ClientTest < TrilogyTest
     result = client.query("SELECT '#{expected}'").to_a.first.first
     assert_equal expected.dup.force_encoding(Encoding::Windows_31J), result
     assert_equal Encoding::Windows_31J, result.encoding
+  end
+
+  def test_connection_options_casting
+    options = {
+      host: DEFAULT_HOST,
+      port: DEFAULT_PORT.to_s,
+      username: DEFAULT_USER,
+      password: DEFAULT_PASS,
+      ssl: "1",
+    }
+    client = new_tcp_client(**options)
+
+    assert client.query("SELECT 1")
   end
 end


### PR DESCRIPTION
Support string ports to make ENV config passing easier. Other gems like mysql2 support this use-case (https://github.com/brianmario/mysql2/blob/master/lib/mysql2/client.rb#L92), so I think trilogy should too.