### PR TITLE
Add `select_db` as an alias for `change_db`

### DIFF
--- a/contrib/ruby/ext/trilogy-ruby/cext.c
+++ b/contrib/ruby/ext/trilogy-ruby/cext.c
@@ -1037,6 +1037,7 @@ RUBY_FUNC_EXPORTED void Init_cext()
 
     rb_define_private_method(Trilogy, "_initialize", rb_trilogy_initialize, 3);
     rb_define_method(Trilogy, "change_db", rb_trilogy_change_db, 1);
+    rb_define_alias(Trilogy, "select_db", "change_db");
     rb_define_method(Trilogy, "query", rb_trilogy_query, 1);
     rb_define_method(Trilogy, "ping", rb_trilogy_ping, 0);
     rb_define_method(Trilogy, "escape", rb_trilogy_escape, 1);

--- a/contrib/ruby/test/client_test.rb
+++ b/contrib/ruby/test/client_test.rb
@@ -102,6 +102,15 @@ class ClientTest < TrilogyTest
     ensure_closed client
   end
 
+  # select_db is just an alias for change_db
+  # and is tested here to ensure it works.
+  def test_trilogy_select_db
+    client = new_tcp_client
+    assert client.select_db "test"
+  ensure
+    ensure_closed client
+  end
+
   def test_trilogy_change_db_after_close_raises
     client = new_tcp_client
     assert client.change_db "test"


### PR DESCRIPTION
`select_db` is the method name in the mysql2 gem and also seems to be the preferred nomenclature in the [mysql documentation](https://dev.mysql.com/doc/c-api/5.7/en/mysql-select-db.html).

AFAICT, both use `COM_INIT_DB` under the hood. Having `select_db` as an alias will make it easier to transition from `mysql2` -> `trilogy` (even if this likely isn't used _that_ frequently)

There seems to be no noticable performance penalty for using the alias, at least with Ruby 3.2.2:

```
ruby 3.2.2 (2023-03-30 revision e51014f9c0) [arm64-darwin22]
Warming up --------------------------------------
              native     1.260M i/100ms
               alias     1.265M i/100ms
Calculating -------------------------------------
              native     12.583M (± 1.0%) i/s -     63.025M in   5.009167s
               alias     12.538M (± 1.0%) i/s -     63.257M in   5.045579s

Comparison:
              native: 12583154.1 i/s
               alias: 12538412.7 i/s - same-ish: difference falls within error
```