### PR TITLE
Use memset_s to clear auth password.

### DIFF
--- a/src/client.c
+++ b/src/client.c
@@ -402,7 +402,11 @@ int trilogy_auth_switch_send(trilogy_conn_t *conn, const trilogy_handshake_t *ha
 void trilogy_auth_clear_password(trilogy_conn_t *conn)
 {
     if (conn->socket->opts.password) {
+        # ifdef __STDC_WANT_LIB_EXT1__
         memset_s(conn->socket->opts.password, conn->socket->opts.password_len, 0, conn->socket->opts.password_len);
+        #else
+        explicit_bzero(conn->socket->opts.password, conn->socket->opts.password_len);
+        #endif
     }
 }
 

--- a/src/client.c
+++ b/src/client.c
@@ -1,4 +1,5 @@
 #include <fcntl.h>
+#include <string.h>
 
 #include "trilogy/client.h"
 #include "trilogy/error.h"
@@ -401,7 +402,7 @@ int trilogy_auth_switch_send(trilogy_conn_t *conn, const trilogy_handshake_t *ha
 void trilogy_auth_clear_password(trilogy_conn_t *conn)
 {
     if (conn->socket->opts.password) {
-        memset(conn->socket->opts.password, 0, conn->socket->opts.password_len);
+        memset_s(conn->socket->opts.password, conn->socket->opts.password_len, 0, conn->socket->opts.password_len);
     }
 }
 


### PR DESCRIPTION
There is a possibility that memset is optimised away, which would be problematic when clearing the password. Thus we replace memset with memset_s which has a far stricter language preventing this optimisation.

fixes https://github.com/trilogy-libraries/trilogy/issues/103