### PR TITLE
Add a reference to the connection from prepared statements

### DIFF
--- a/inc/trilogy/client.h
+++ b/inc/trilogy/client.h
@@ -63,6 +63,8 @@
  */
 typedef trilogy_column_packet_t trilogy_column_t;
 
+typedef struct trilogy_stmt trilogy_stmt_t;
+
 /* trilogy_conn_t - The Trilogy client's instance type.
  *
  * This type is shared for the non-blocking and blocking versions of the API.
@@ -82,6 +84,7 @@ typedef struct {
     uint16_t server_status;
 
     trilogy_sock_t *socket;
+    trilogy_stmt_t *prepared_statements;
 
     // private:
     uint8_t recv_buff[TRILOGY_DEFAULT_BUF_SIZE];
@@ -619,7 +622,16 @@ int trilogy_stmt_prepare_send(trilogy_conn_t *conn, const char *stmt, size_t stm
 
 /* trilogy_stmt_t - The trilogy client's prepared statement type.
  */
-typedef trilogy_stmt_ok_packet_t trilogy_stmt_t;
+
+struct trilogy_stmt {
+    trilogy_stmt_t *prev;
+    trilogy_stmt_t *next;
+    uint32_t id;
+    uint16_t column_count;
+    uint16_t parameter_count;
+    uint16_t warning_count;
+    trilogy_conn_t *connection;
+};
 
 /* trilogy_stmt_prepare_recv - Read the prepared statement prepare command response
  * from the MySQL-compatible server.

--- a/src/client.c
+++ b/src/client.c
@@ -145,6 +145,8 @@ int trilogy_init(trilogy_conn_t *conn)
     conn->recv_buff_pos = 0;
     conn->recv_buff_len = 0;
 
+    conn->prepared_statements = NULL;
+
     trilogy_packet_parser_init(&conn->packet_parser, &packet_parser_callbacks);
     conn->packet_parser.user_data = &conn->packet_buffer;
 
@@ -765,6 +767,12 @@ void trilogy_free(trilogy_conn_t *conn)
         conn->socket = NULL;
     }
 
+    trilogy_stmt_t *stmt = conn->prepared_statements;
+    while (stmt) {
+        stmt->connection = NULL;
+        stmt = stmt->next;
+    }
+
     trilogy_buffer_free(&conn->packet_buffer);
 }
 
@@ -803,13 +811,19 @@ int trilogy_stmt_prepare_recv(trilogy_conn_t *conn, trilogy_stmt_t *stmt_out)
 
     switch (current_packet_type(conn)) {
     case TRILOGY_PACKET_OK: {
-        err = trilogy_parse_stmt_ok_packet(conn->packet_buffer.buff, conn->packet_buffer.len, stmt_out);
+        trilogy_stmt_ok_packet_t out_packet;
+        err = trilogy_parse_stmt_ok_packet(conn->packet_buffer.buff, conn->packet_buffer.len, &out_packet);
 
         if (err < 0) {
             return err;
         }
 
         conn->warning_count = stmt_out->warning_count;
+        stmt_out->connection = conn;
+        stmt_out->id = out_packet.id;
+        stmt_out->column_count = out_packet.column_count;
+        stmt_out->parameter_count = out_packet.parameter_count;
+        stmt_out->warning_count = out_packet.warning_count;
 
         return TRILOGY_OK;
     }


### PR DESCRIPTION
Ref: https://github.com/trilogy-libraries/trilogy/issues/105

To close a prepared statement you need to have access to the connection that created it.

But in managed languages like Ruby, the obvious thing to do is to close the prepared statement when the associated object is garbage collected.

But the order in which objects are garbaged collected is never guaranteed so when freeing a statement the connection might have been freed already and it's hard to detect.

We checked how libmysqlclient handles it, and each `MYSQL_STMT` has a reference to its `MYSQL` (connection), and the connection keeps a doubly linked list of the statements it created.

When a statement is closed it's removed from the list, when the connection is closed, all the connection references are set to NULL.

We implemented exactly the same logic here.

Additionally, prepared statement can only be used with the connection they were created from. As such having all the `trilogy_stmt_*` function take a connection isn't great for usability. So this change opens the door to only taking a `trilogy_stmt_t *`.