### PR TITLE
Improve wait callback and timeout handling

### DIFF
--- a/contrib/ruby/ext/trilogy-ruby/cext.c
+++ b/contrib/ruby/ext/trilogy-ruby/cext.c
@@ -113,6 +113,9 @@ static void handle_trilogy_error(struct trilogy_ctx *ctx, int rc, const char *ms
         trilogy_syserr_fail_str(errno, rbmsg);
 
     case TRILOGY_TIMEOUT:
+        if (ctx->conn.socket != NULL) {
+            trilogy_sock_shutdown(ctx->conn.socket);
+        }
         rb_raise(Trilogy_TimeoutError, "%" PRIsVALUE, rbmsg);
 
     case TRILOGY_ERR: {

--- a/contrib/ruby/ext/trilogy-ruby/cext.c
+++ b/contrib/ruby/ext/trilogy-ruby/cext.c
@@ -112,6 +112,9 @@ static void handle_trilogy_error(struct trilogy_ctx *ctx, int rc, const char *ms
     case TRILOGY_SYSERR:
         trilogy_syserr_fail_str(errno, rbmsg);
 
+    case TRILOGY_TIMEOUT:
+        rb_raise(Trilogy_TimeoutError, "%" PRIsVALUE, rbmsg);
+
     case TRILOGY_ERR: {
         VALUE message = rb_str_new(ctx->conn.error_message, ctx->conn.error_message_len);
         VALUE exc = rb_funcall(Trilogy_ProtocolError, id_from_code, 2, message, INT2NUM(ctx->conn.error_code));
@@ -167,8 +170,9 @@ static int flush_writes(struct trilogy_ctx *ctx)
             return rc;
         }
 
-        if (trilogy_sock_wait_write(ctx->conn.socket) < 0) {
-            rb_raise(Trilogy_TimeoutError, "trilogy_flush_writes");
+        rc = trilogy_sock_wait_write(ctx->conn.socket);
+        if (rc != TRILOGY_OK) {
+            return rc;
         }
     }
 }
@@ -218,10 +222,13 @@ static int _cb_ruby_wait(trilogy_sock_t *sock, trilogy_wait_t wait)
     }
 
     int fd = trilogy_sock_fd(sock);
-    if (rb_wait_for_single_fd(fd, wait_flag, timeout) <= 0)
+    int rc = rb_wait_for_single_fd(fd, wait_flag, timeout);
+    if (rc < 0)
         return TRILOGY_SYSERR;
+    if (rc == 0)
+        return TRILOGY_TIMEOUT;
 
-    return 0;
+    return TRILOGY_OK;
 }
 
 struct nogvl_sock_args {
@@ -273,8 +280,10 @@ escape the GVL on each wait operation without going through call_without_gvl */
             return rc;
         }
 
-        if (trilogy_sock_wait(ctx->conn.socket, TRILOGY_WAIT_HANDSHAKE) < 0)
-            return TRILOGY_TIMEOUT;
+        rc = trilogy_sock_wait(ctx->conn.socket, TRILOGY_WAIT_HANDSHAKE);
+        if (rc != TRILOGY_OK) {
+            return rc;
+        }
     }
 }
 
@@ -301,8 +310,9 @@ static void auth_switch(struct trilogy_ctx *ctx, trilogy_handshake_t *handshake)
             handle_trilogy_error(ctx, rc, "trilogy_auth_recv");
         }
 
-        if (trilogy_sock_wait_read(ctx->conn.socket) < 0) {
-            rb_raise(Trilogy_TimeoutError, "trilogy_auth_recv");
+        rc = trilogy_sock_wait_read(ctx->conn.socket);
+        if (rc != TRILOGY_OK) {
+            handle_trilogy_error(ctx, rc, "trilogy_auth_recv");
         }
     }
 }
@@ -354,8 +364,9 @@ static void authenticate(struct trilogy_ctx *ctx, trilogy_handshake_t *handshake
             handle_trilogy_error(ctx, rc, "trilogy_auth_recv");
         }
 
-        if (trilogy_sock_wait_read(ctx->conn.socket) < 0) {
-            rb_raise(Trilogy_TimeoutError, "trilogy_auth_recv");
+        rc = trilogy_sock_wait_read(ctx->conn.socket);
+        if (rc != TRILOGY_OK) {
+            handle_trilogy_error(ctx, rc, "trilogy_auth_recv");
         }
     }
 
@@ -564,8 +575,9 @@ static VALUE rb_trilogy_change_db(VALUE self, VALUE database)
             handle_trilogy_error(ctx, rc, "trilogy_change_db_recv");
         }
 
-        if (trilogy_sock_wait_read(ctx->conn.socket) < 0) {
-            rb_raise(Trilogy_TimeoutError, "trilogy_change_db_recv");
+        rc = trilogy_sock_wait_read(ctx->conn.socket);
+        if (rc != TRILOGY_OK) {
+            handle_trilogy_error(ctx, rc, "trilogy_change_db_recv");
         }
     }
 
@@ -597,8 +609,9 @@ static VALUE rb_trilogy_set_server_option(VALUE self, VALUE option)
             handle_trilogy_error(ctx, rc, "trilogy_set_option_recv");
         }
 
-        if (trilogy_sock_wait_read(ctx->conn.socket) < 0) {
-            rb_raise(Trilogy_TimeoutError, "trilogy_set_option_recv");
+        rc = trilogy_sock_wait_read(ctx->conn.socket);
+        if (rc != TRILOGY_OK) {
+            handle_trilogy_error(ctx, rc, "trilogy_set_option_recv");
         }
     }
 
@@ -670,8 +683,9 @@ static VALUE read_query_response(VALUE vargs)
             return read_query_error(args, rc, "trilogy_query_recv");
         }
 
-        if (trilogy_sock_wait_read(ctx->conn.socket) < 0) {
-            rb_raise(Trilogy_TimeoutError, "trilogy_query_recv");
+        rc = trilogy_sock_wait_read(ctx->conn.socket);
+        if (rc != TRILOGY_OK) {
+            handle_trilogy_error(ctx, rc, "trilogy_query_recv");
         }
     }
 
@@ -719,8 +733,9 @@ static VALUE read_query_response(VALUE vargs)
                 return read_query_error(args, rc, "trilogy_read_column");
             }
 
-            if (trilogy_sock_wait_read(ctx->conn.socket) < 0) {
-                rb_raise(Trilogy_TimeoutError, "trilogy_read_column");
+            rc = trilogy_sock_wait_read(ctx->conn.socket);
+            if (rc != TRILOGY_OK) {
+                return read_query_error(args, rc, "trilogy_read_column");
             }
         }
 
@@ -747,8 +762,9 @@ static VALUE read_query_response(VALUE vargs)
         int rc = trilogy_read_row(&ctx->conn, row_values);
 
         if (rc == TRILOGY_AGAIN) {
-            if (trilogy_sock_wait_read(ctx->conn.socket) < 0) {
-                rb_raise(Trilogy_TimeoutError, "trilogy_read_row");
+            rc = trilogy_sock_wait_read(ctx->conn.socket);
+            if (rc != TRILOGY_OK) {
+                return read_query_error(args, rc, "trilogy_read_row");
             }
             continue;
         }
@@ -874,8 +890,9 @@ static VALUE rb_trilogy_ping(VALUE self)
             handle_trilogy_error(ctx, rc, "trilogy_ping_recv");
         }
 
-        if (trilogy_sock_wait_read(ctx->conn.socket) < 0) {
-            rb_raise(Trilogy_TimeoutError, "trilogy_ping_recv");
+        rc = trilogy_sock_wait_read(ctx->conn.socket);
+        if (rc != TRILOGY_OK) {
+            handle_trilogy_error(ctx, rc, "trilogy_ping_recv");
         }
     }
 

--- a/contrib/ruby/ext/trilogy-ruby/cext.c
+++ b/contrib/ruby/ext/trilogy-ruby/cext.c
@@ -15,8 +15,6 @@
 
 #include "trilogy-ruby.h"
 
-#define TRILOGY_RB_TIMEOUT 1
-
 VALUE Trilogy_CastError;
 static VALUE Trilogy_BaseConnectionError, Trilogy_ProtocolError, Trilogy_SSLError, Trilogy_QueryError,
     Trilogy_ConnectionClosedError, Trilogy_ConnectionRefusedError, Trilogy_ConnectionResetError,
@@ -276,7 +274,7 @@ escape the GVL on each wait operation without going through call_without_gvl */
         }
 
         if (trilogy_sock_wait(ctx->conn.socket, TRILOGY_WAIT_HANDSHAKE) < 0)
-            return TRILOGY_RB_TIMEOUT;
+            return TRILOGY_TIMEOUT;
     }
 }
 
@@ -519,7 +517,7 @@ static VALUE rb_trilogy_initialize(VALUE self, VALUE encoding, VALUE charset, VA
     }
 
     int rc = try_connect(ctx, &handshake, &connopt);
-    if (rc == TRILOGY_RB_TIMEOUT) {
+    if (rc == TRILOGY_TIMEOUT) {
         rb_raise(Trilogy_TimeoutError, "trilogy_connect_recv");
     }
     if (rc != TRILOGY_OK) {

--- a/contrib/ruby/ext/trilogy-ruby/cext.c
+++ b/contrib/ruby/ext/trilogy-ruby/cext.c
@@ -252,6 +252,8 @@ static int _cb_ruby_wait(trilogy_sock_t *sock, trilogy_wait_t wait)
         rb_jump_tag(state);
     }
 
+    // rc here comes from rb_wait_for_single_fd which (similar to poll(3)) returns 0 to indicate that the call timed out
+    // or -1 to indicate a system error with errno set.
     if (args.rc < 0)
         return TRILOGY_SYSERR;
     if (args.rc == 0)

--- a/inc/trilogy/error.h
+++ b/inc/trilogy/error.h
@@ -23,7 +23,8 @@
     XX(TRILOGY_DNS_ERR, -18)                                                                                           \
     XX(TRILOGY_AUTH_SWITCH, -19)                                                                                       \
     XX(TRILOGY_MAX_PACKET_EXCEEDED, -20)                                                                               \
-    XX(TRILOGY_UNKNOWN_TYPE, -21)
+    XX(TRILOGY_UNKNOWN_TYPE, -21)                                                                                      \
+    XX(TRILOGY_TIMEOUT, -22)
 
 enum {
 #define XX(name, code) name = code,


### PR DESCRIPTION
This makes a couple improvements to how we wait for the socket to become ready for I/O.

First this refactors `TRILOGY_RB_TIMEOUT` to a "real" error status in the C library (though currently nothing in the C library raises it), which allows it to be negative like all the other errors (and avoids being confused with a successful read/write of size 1).

Next this makes `_cb_ruby_wait` return this new status code instead of SYSERR when there is a timeout, allowing it to propogate through `trilogy_sock_upgrade_ssl` and similar correctly. This allows differentiating between actually syserrors which set errno and timeouts. Also this can show the difference between `rb_wait_for_single_fd` returning `-1` (a syscall error, which I think in practice will be extremely rare) and 0 (a timeout).

Finally the last two commits ensure that the socket is shut down on either a socket timeout we see, or from an external exception (like `Timeout.timeout`). For the latter we must wrap the waiting in an `rb_protect`, which previously we were doing correctly for queries, but not for other operations (ex. `ping`, `change_db`). We have to shut down the socket because we've interrupted normal control flow and are likely either in the middle of a write (we've partly written our packet) or a read (there will be data sent from the server that we need to handle) so any further operations are invalid.