### PR TITLE
Fixes to OpenSSL error handling

### DIFF
--- a/contrib/ruby/ext/trilogy-ruby/cext.c
+++ b/contrib/ruby/ext/trilogy-ruby/cext.c
@@ -94,6 +94,9 @@ static void trilogy_syserr_fail_str(int e, VALUE msg)
         rb_raise(Trilogy_ConnectionRefusedError, "%" PRIsVALUE, msg);
     } else if (e == ECONNRESET) {
         rb_raise(Trilogy_ConnectionResetError, "%" PRIsVALUE, msg);
+    } else if (e == EPIPE) {
+        // Backwards compatibility: This error class makes no sense, but matches legacy behavior
+        rb_raise(Trilogy_QueryError, "%" PRIsVALUE ": TRILOGY_CLOSED_CONNECTION", msg);
     } else {
         VALUE exc = rb_funcall(Trilogy_SyscallError, id_from_errno, 2, INT2NUM(e), msg);
         rb_exc_raise(exc);

--- a/contrib/ruby/ext/trilogy-ruby/cext.c
+++ b/contrib/ruby/ext/trilogy-ruby/cext.c
@@ -994,6 +994,10 @@ static VALUE rb_trilogy_close(VALUE self)
         }
     }
 
+    // We aren't checking or raising errors here (we need close to always close the socket and free the connection), so
+    // we must clear any SSL errors left in the queue from a read/write.
+    ERR_clear_error();
+
     trilogy_free(&ctx->conn);
 
     return Qnil;

--- a/contrib/ruby/ext/trilogy-ruby/cext.c
+++ b/contrib/ruby/ext/trilogy-ruby/cext.c
@@ -100,6 +100,17 @@ static void trilogy_syserr_fail_str(int e, VALUE msg)
     }
 }
 
+static int trilogy_error_recoverable_p(int rc)
+{
+    // TRILOGY_OPENSSL_ERR and TRILOGY_SYSERR (which can result from an SSL error) must shut down the socket, as further
+    // SSL calls would be invalid.
+    // TRILOGY_ERR, which represents an error message sent to us from the server, is recoverable.
+    // TRILOGY_MAX_PACKET_EXCEEDED is also recoverable as we do not send data when it occurs.
+    // For other exceptions we will also close the socket to prevent further use, as the connection is probably in an
+    // invalid state.
+    return rc == TRILOGY_ERR || rc == TRILOGY_MAX_PACKET_EXCEEDED;
+}
+
 NORETURN(static void handle_trilogy_error(struct trilogy_ctx *, int, const char *, ...));
 static void handle_trilogy_error(struct trilogy_ctx *ctx, int rc, const char *msg, ...)
 {
@@ -108,14 +119,20 @@ static void handle_trilogy_error(struct trilogy_ctx *ctx, int rc, const char *ms
     VALUE rbmsg = rb_vsprintf(msg, args);
     va_end(args);
 
+    if (!trilogy_error_recoverable_p(rc)) {
+        if (ctx->conn.socket != NULL) {
+            // trilogy_sock_shutdown may affect errno
+            int errno_was = errno;
+            trilogy_sock_shutdown(ctx->conn.socket);
+            errno = errno_was;
+        }
+    }
+
     switch (rc) {
     case TRILOGY_SYSERR:
         trilogy_syserr_fail_str(errno, rbmsg);
 
     case TRILOGY_TIMEOUT:
-        if (ctx->conn.socket != NULL) {
-            trilogy_sock_shutdown(ctx->conn.socket);
-        }
         rb_raise(Trilogy_TimeoutError, "%" PRIsVALUE, rbmsg);
 
     case TRILOGY_ERR: {
@@ -130,11 +147,6 @@ static void handle_trilogy_error(struct trilogy_ctx *ctx, int rc, const char *ms
         if (ERR_GET_LIB(ossl_error) == ERR_LIB_SYS) {
             int err_reason = ERR_GET_REASON(ossl_error);
             trilogy_syserr_fail_str(err_reason, rbmsg);
-        }
-        // We can't recover from OpenSSL level errors if there's
-        // an active connection.
-        if (ctx->conn.socket != NULL) {
-            trilogy_sock_shutdown(ctx->conn.socket);
         }
         rb_raise(Trilogy_SSLError, "%" PRIsVALUE ": SSL Error: %s", rbmsg, ERR_reason_error_string(ossl_error));
     }

--- a/contrib/ruby/test/client_test.rb
+++ b/contrib/ruby/test/client_test.rb
@@ -773,6 +773,8 @@ class ClientTest < TrilogyTest
     end
 
     assert_equal "trilogy_query_send: TRILOGY_MAX_PACKET_EXCEEDED", exception.message
+
+    assert client.ping
   ensure
     ensure_closed client
   end
@@ -791,6 +793,8 @@ class ClientTest < TrilogyTest
     end
 
     assert_equal "trilogy_query_send: TRILOGY_MAX_PACKET_EXCEEDED", exception.message
+
+    assert client.ping
   ensure
     ensure_closed client
   end
@@ -809,6 +813,8 @@ class ClientTest < TrilogyTest
     end
 
     assert_equal "trilogy_query_send: TRILOGY_MAX_PACKET_EXCEEDED", exception.message
+
+    assert client.ping
   ensure
     ensure_closed client
   end
@@ -833,6 +839,10 @@ class ClientTest < TrilogyTest
     end
 
     refute_match(/TRILOGY_MAX_PACKET_EXCEEDED/, exception.message)
+
+    exception = assert_raises_connection_error do
+      client.ping
+    end
   ensure
     ensure_closed client
   end
@@ -851,6 +861,8 @@ class ClientTest < TrilogyTest
     end
 
     assert_equal "trilogy_query_send: TRILOGY_MAX_PACKET_EXCEEDED", exception.message
+
+    assert client.ping
   ensure
     ensure_closed client
   end

--- a/contrib/ruby/test/client_test.rb
+++ b/contrib/ruby/test/client_test.rb
@@ -840,7 +840,7 @@ class ClientTest < TrilogyTest
 
     refute_match(/TRILOGY_MAX_PACKET_EXCEEDED/, exception.message)
 
-    exception = assert_raises_connection_error do
+    assert_raises_connection_error do
       client.ping
     end
   ensure

--- a/contrib/ruby/test/test_helper.rb
+++ b/contrib/ruby/test/test_helper.rb
@@ -139,6 +139,8 @@ class TrilogyTest < Minitest::Test
 
     if err.is_a?(Trilogy::QueryError)
       assert_includes err.message, "TRILOGY_CLOSED_CONNECTION"
+    elsif err.is_a?(Trilogy::SSLError)
+      assert_includes err.message, "unexpected eof while reading"
     else
       assert_instance_of Trilogy::ConnectionResetError, err
     end

--- a/src/client.c
+++ b/src/client.c
@@ -1,4 +1,3 @@
-#include <errno.h>
 #include <fcntl.h>
 
 #include "trilogy/client.h"
@@ -76,11 +75,6 @@ static int read_packet(trilogy_conn_t *conn)
 
         if (nread < 0) {
             int rc = (int)nread;
-            if (rc == TRILOGY_SYSERR) {
-                if (errno == EINTR || errno == EAGAIN) {
-                    return TRILOGY_AGAIN;
-                }
-            }
             return rc;
         }
 
@@ -162,16 +156,6 @@ int trilogy_flush_writes(trilogy_conn_t *conn)
 
     if (bytes < 0) {
         int rc = (int)bytes;
-        if (rc == TRILOGY_SYSERR) {
-            if (errno == EINTR || errno == EAGAIN) {
-                return TRILOGY_AGAIN;
-            }
-
-            if (errno == EPIPE) {
-                return TRILOGY_CLOSED_CONNECTION;
-            }
-        }
-
         return rc;
     }
 

--- a/src/socket.c
+++ b/src/socket.c
@@ -339,6 +339,11 @@ static ssize_t ssl_io_return(struct trilogy_sock *sock, ssize_t ret)
 static ssize_t _cb_ssl_read(trilogy_sock_t *_sock, void *buf, size_t nread)
 {
     struct trilogy_sock *sock = (struct trilogy_sock *)_sock;
+
+    // This shouldn't be necessary, but protects against other libraries in the same process incorrectly leaving errors
+    // in the queue.
+    ERR_clear_error();
+
     ssize_t data_read = (ssize_t)SSL_read(sock->ssl, buf, (int)nread);
     return ssl_io_return(sock, data_read);
 }
@@ -346,6 +351,11 @@ static ssize_t _cb_ssl_read(trilogy_sock_t *_sock, void *buf, size_t nread)
 static ssize_t _cb_ssl_write(trilogy_sock_t *_sock, const void *buf, size_t nwrite)
 {
     struct trilogy_sock *sock = (struct trilogy_sock *)_sock;
+
+    // This shouldn't be necessary, but protects against other libraries in the same process incorrectly leaving errors
+    // in the queue.
+    ERR_clear_error();
+
     ssize_t data_written = (ssize_t)SSL_write(sock->ssl, buf, (int)nwrite);
     return ssl_io_return(sock, data_written);
 }
@@ -560,6 +570,10 @@ int trilogy_sock_upgrade_ssl(trilogy_sock_t *_sock)
 {
     struct trilogy_sock *sock = (struct trilogy_sock *)_sock;
 
+    // This shouldn't be necessary, but protects against other libraries in the same process incorrectly leaving errors
+    // in the queue.
+    ERR_clear_error();
+
     SSL_CTX *ctx = trilogy_ssl_ctx(&sock->base.opts);
 
     if (!ctx) {
@@ -602,6 +616,10 @@ int trilogy_sock_upgrade_ssl(trilogy_sock_t *_sock)
         goto fail;
 
     for (;;) {
+        // This shouldn't be necessary, but protects against other libraries in the same process incorrectly leaving errors
+        // in the queue.
+        ERR_clear_error();
+
         int ret = SSL_connect(sock->ssl);
         if (ret == 1) {
 #if OPENSSL_VERSION_NUMBER < 0x1000200fL

--- a/src/socket.c
+++ b/src/socket.c
@@ -357,7 +357,10 @@ static int _cb_ssl_close(trilogy_sock_t *_sock)
     struct trilogy_sock *sock = (struct trilogy_sock *)_sock;
     if (sock->ssl != NULL) {
         if (SSL_in_init(sock->ssl) == 0) {
-            SSL_shutdown(sock->ssl);
+            (void)SSL_shutdown(sock->ssl);
+            // SSL_shutdown might return WANT_WRITE or WANT_READ. Ideally we would retry but we don't want to block.
+            // It may also push an error onto the OpenSSL error queue, so clear that.
+            ERR_clear_error();
         }
         SSL_free(sock->ssl);
         sock->ssl = NULL;


### PR DESCRIPTION
This fixes a number of issues with our OpenSSL integration.

First this ensures that the socket is shutdown (or closed post-#111) after error from OpenSSL. Previously we only closed the connection on `TRILOGY_OPENSSL_ERR` but not on a `TRILOGY_CLOSED_CONNECTION` or `TRILOGY_SYSERR` which could be returned/translated from an error in OpenSSL. As SSL holds its own buffers we must not attempt anything (including `SSL_shutdown`) after a failure from `SSL_read` or `SSL_write`.

To address that this also makes ALL exceptions (other than `TRILOGY_ERR` and `TRILOGY_MAX_PACKET_EXCEEDED`) shutdown the connection. These exceptions don't generally indicate something recoverable (if we get an error from a syscall other than EAGAIN, which we handle specially, we're likely to keep seeing it) and even if it was recoverable these exceptions happen in while we're in an inconsistent state (writing, or while expecting more data from the server), attempts to send a new packet from the start will be invalid.

Next this moves some translation based on `errno` from `client.c` to make it specific to raw sockets. I believe an OpenSSL socket will return `SSL_ERROR_WANT_WRITE` or `SSL_ERROR_WANT_READ` in any case the underlying socket returns EAGAIN, but that's not an assumption we should be making on the return value. OpenSSL has its own buffers and we can only retry when it tells us to. This also moves the translation of EPIPE to the raw socket, but also special cases it in `trilogy_syserr_fail_str` for backwards compatibility. `client.c` should be threating the socket like a black box not be assuming that it is backed by system calls.

Next this fixes checks on the return value from `SSL_read` and `SSL_write`. A return value of 0 is an error. Previously we incorrectly assumed that return value held the same meaning as from `read` or `write`, which is incorrect. Usually this happened on an unexpected EOF from the socket (which we'd happen to treat correctly, assuming the same meaning as `read`), but looking through the OpenSSL source 0 can mean a number of other errors. Instead this now adds a check for the case described in the [SSL_get_error's man page "BUG" section](https://www.openssl.org/docs/man1.1.1/man3/SSL_get_error.html).

> The SSL_ERROR_SYSCALL with errno value of 0 indicates unexpected EOF from the peer. This will be properly reported as SSL_ERROR_SSL with reason code SSL_R_UNEXPECTED_EOF_WHILE_READING in the OpenSSL 3.0 release because it is truly a TLS protocol error to terminate the connection without a SSL_shutdown().
> 
> The issue is kept unfixed in OpenSSL 1.1.1 releases because many applications which choose to ignore this protocol error depend on the existing way of reporting the error.

Additionally this clears any SSL errors inside `rb_trilogy_close`. We don't check whether `trilogy_close_send`/`trilogy_close_recv` return an error, which is (probably) fine: we're closing the socket, but we must clear any OpenSSL errors which are left on the stack from that read/write operation.

Finally, this adds a call to `ERR_clear_error()` before every OpenSSL operation. This is a workaround due to other libraries which incorrectly leave unhandled errors in the global (thread-local) OpenSSL error queue. This is a workaround other libraries also seem to have adopted (ones I know of: libpq and libcurl, the later of which ironically is responsible for causing this problem).

I would be happy to not look at OpenSSL for a while after this 😅

cc @adrianna-chang-shopify @casperisfine @composerinteralia @matthewd 