### PR TITLE
Ruby: Better handle `port: nil`

### DIFF
--- a/contrib/ruby/lib/trilogy.rb
+++ b/contrib/ruby/lib/trilogy.rb
@@ -8,7 +8,7 @@ require "trilogy/encoding"
 
 class Trilogy
   def initialize(options = {})
-    options[:port] = options[:port].to_i if options.key?(:port)
+    options[:port] = options[:port].to_i if options[:port]
     mysql_encoding = options[:encoding] || "utf8mb4"
     encoding = Trilogy::Encoding.find(mysql_encoding)
     charset = Trilogy::Encoding.charset(mysql_encoding)


### PR DESCRIPTION
Previously `nil` would be handled as using the default port, now it's casted to port=0 which generally isn't what you want.

cc @adrianna-chang-shopify 