### PR TITLE
Introduce EOFError and make SyscallError < ConnectionError

### DIFF
--- a/contrib/ruby/lib/trilogy/error.rb
+++ b/contrib/ruby/lib/trilogy/error.rb
@@ -20,7 +20,7 @@ class Trilogy
       .select { |c| c.is_a?(Class) && c < SystemCallError }
       .each do |c|
         errno_name = c.to_s.split('::').last
-        ERRORS[c::Errno] = const_set(errno_name, Class.new(c) { include Trilogy::Error })
+        ERRORS[c::Errno] = const_set(errno_name, Class.new(c) { include Trilogy::ConnectionError })
       end
 
     ERRORS.freeze

--- a/contrib/ruby/lib/trilogy/error.rb
+++ b/contrib/ruby/lib/trilogy/error.rb
@@ -112,7 +112,13 @@ class Trilogy
     include ConnectionError
   end
 
+  # Raised on attempt to use connection which was explicitly closed by the user
   class ConnectionClosed < IOError
     include ConnectionError
+  end
+
+  # Occurrs when a socket read or write returns EOF or when an operation is
+  # attempted on a socket which previously encountered an error.
+  class EOFError < BaseConnectionError
   end
 end

--- a/contrib/ruby/test/test_helper.rb
+++ b/contrib/ruby/test/test_helper.rb
@@ -137,7 +137,7 @@ class TrilogyTest < Minitest::Test
   def assert_raises_connection_error(&block)
     err = assert_raises(Trilogy::Error, &block)
 
-    if err.is_a?(Trilogy::QueryError)
+    if err.is_a?(Trilogy::EOFError)
       assert_includes err.message, "TRILOGY_CLOSED_CONNECTION"
     elsif err.is_a?(Trilogy::SSLError)
       assert_includes err.message, "unexpected eof while reading"


### PR DESCRIPTION
This makes two of the changes there seems to be consensus around from https://github.com/trilogy-libraries/trilogy/issues/113

First this introduces `EOFError`, which represents `TRILOGY_CLOSED_CONNECTION`. It's a subclass of `BaseConnectionError`, but distinct from `ConnectionClosed` (which represents an explicit `.close` from the client's side).

Second this makes `Trilogy::SyscallError::*` all include the `ConnectionError` module, allowing `rescue ConnectionError` to catch most types of network communication issue.