### PR TITLE
Feature: add `#empty?` method to result class

### DIFF
--- a/contrib/ruby/lib/trilogy/result.rb
+++ b/contrib/ruby/lib/trilogy/result.rb
@@ -6,6 +6,10 @@ class Trilogy
       rows.count
     end
 
+    def empty?
+      rows.empty?
+    end
+
     def each_hash
       return enum_for(:each_hash) unless block_given?
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -23,7 +23,7 @@ services:
       args:
         - DISTRIBUTION=${DISTRIBUTION}
         - RUBY_VERSION=${RUBY_VERSION}
-      cache_from: 
+      cache_from:
         - ghcr.io/trilogy-libraries/trilogy/ci-app:distro-${DISTRIBUTION_SLUG}-ruby-${RUBY_VERSION}-mysql-${MYSQL_VERSION}
     environment:
       MYSQL_HOST: db.local


### PR DESCRIPTION
# Purpose
I'm working on switching our Rails monolith from using the `mysql2` adapter to `trilogy`.  One of the things that came up was the Public API varies from `ActiveRecord::Result` and `Trilogy::Result`

## `ActiveRecord::Result` API difference
As you can see [here](https://github.com/rails/rails/blob/main/activerecord/lib/active_record/result.rb#L79) there's a public method `#empty?` and other gems have implemented features around that API.

# Gem impacted
[composite_primary_keys](https://github.com/composite-primary-keys/composite_primary_keys/blob/master/lib/composite_primary_keys/connection_adapters/abstract/database_statements.rb#L10) expects for there to be a public method to respond to `#empty?`, but since there isn't one currently the user sees 

```bash
NoMethodError: undefined method `[]' for nil:NilClass
```

I debated opening up a PR in the impacted gem or here, but I decided that this is where I'd start.

# Test
I didn't see any current test for this file, it'd be pretty a simple test since we're just checking `#empty?`