### PR TITLE
Set TCP_NODELAY

### DIFF
--- a/src/socket.c
+++ b/src/socket.c
@@ -195,6 +195,14 @@ static int raw_connect_internal(struct trilogy_sock *sock, const struct addrinfo
         return TRILOGY_SYSERR;
     }
 
+#ifdef TCP_NODELAY
+    if (sock->addr->ai_family != PF_UNIX) {
+        int flags = 1;
+        if (setsockopt(sock->fd, IPPROTO_TCP, TCP_NODELAY, (void *)&flags, sizeof(flags)) < 0) {
+            goto fail;
+        }
+    }
+#endif
     if (sock->base.opts.keepalive_enabled) {
         int flags = 1;
         if (setsockopt(sock->fd, SOL_SOCKET, SO_KEEPALIVE, (void *)&flags, sizeof(flags)) < 0) {


### PR DESCRIPTION
This PR sets the `TCP_NODELAY` flag on sockets.

Sometimes, when clients use SSL, Nagle's could cause increased connection latency. We were seeing around 40ms additional latency.