### PR TITLE
Provide explicit docker-compose platform for Apple Silicon

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,6 +1,7 @@
 version: "3.5"
 services:
   db:
+    platform: linux/x86_64
     image: "mysql:${MYSQL_VERSION}-debian"
     command:
     - --sql_mode=NO_ENGINE_SUBSTITUTION


### PR DESCRIPTION
There is (still) not yet a `mysql:8.0-debian` image compatible with linux/arm64/v8, which prevents `docker-compose.yml` from building on Apple Silicon / M1, etc. processors.

> `no matching manifest for linux/arm64/v8 in the manifest list entries`

This PR sets an explicit platform so that Docker will use the x86_64 image with emulation.