### PR TITLE
Report EOFError: TRILOGY_CLOSED_CONNECTION for SSL_ERROR_ZERO_RETURN

### DIFF
--- a/src/socket.c
+++ b/src/socket.c
@@ -377,6 +377,9 @@ static ssize_t ssl_io_return(struct trilogy_sock *sock, ssize_t ret)
         int rc = SSL_get_error(sock->ssl, (int)ret);
         if (rc == SSL_ERROR_WANT_WRITE || rc == SSL_ERROR_WANT_READ) {
             return (ssize_t)TRILOGY_AGAIN;
+        } else if (rc == SSL_ERROR_ZERO_RETURN) {
+            // Server has closed the connection for writing by sending the close_notify alert
+            return (ssize_t)TRILOGY_CLOSED_CONNECTION;
         } else if (rc == SSL_ERROR_SYSCALL && !ERR_peek_error()) {
             if (errno == 0) {
                 // On OpenSSL <= 1.1.1, SSL_ERROR_SYSCALL with an errno value


### PR DESCRIPTION
Fixes #125

If a server closes the SSL connection cleanly (`SSL_shutdown`) as we attempt a read or write (ie. a clean SSL shutdown but dirty MySQL shutdown) we will get `SSL_ERROR_ZERO_RETURN` as the return code.

Previously we would have reported this as:

    Trilogy::SSLError: trilogy_query_recv: SSL Error: (null)

Now it will be reported as:

    Trilogy::EOFError: trilogy_query_recv: TRILOGY_CLOSED_CONNECTION

On older versions (< 2.5.0) we may also have been reporting this as `TRILOGY_CLOSED_CONNECTION`.