### PR TITLE
Trilogy is much slower than mysql2 to connect to an IP

### DIFF
--- a/contrib/ruby/script/benchmark-connect
+++ b/contrib/ruby/script/benchmark-connect
@@ -9,24 +9,29 @@ require "mysql2"
 
 DEFAULT_USER = ENV["MYSQL_USER"] || "root"
 DEFAULT_PASS = ENV["MYSQL_PASS"]
-DEFAULT_SOCK = ENV["MYSQL_SOCK"] || "/tmp/mysql.sock"
 
 connect_options = {
-  path:     DEFAULT_SOCK, # for trilogy
-  socket:   DEFAULT_SOCK, # for mysql2
   username: DEFAULT_USER,
   password: DEFAULT_PASS,
-  host: "localhost",
+  host: "127.0.0.1",
 }
 
+client = Trilogy.new(connect_options)
+p client.query("SELECT 1")
+client = Mysql2::Client.new(connect_options)
+p client.query("SELECT 1")
+
+puts "===  Connecting to 'localhost'. "
 Benchmark.ips do |x|
   x.report "trilogy connect/close" do
     client = Trilogy.new(connect_options)
+    client.query("SELECT 1")
     client.close
   end
 
   x.report "mysql2 connect/close" do
     client = Mysql2::Client.new(connect_options)
+    client.query("SELECT 1")
     client.close
   end
 

--- a/contrib/ruby/script/benchmark-connect
+++ b/contrib/ruby/script/benchmark-connect
@@ -1,0 +1,34 @@
+#!/usr/bin/env ruby
+
+require "rubygems" if !defined?(Gem)
+require "bundler/setup"
+
+require "benchmark/ips"
+require "trilogy"
+require "mysql2"
+
+DEFAULT_USER = ENV["MYSQL_USER"] || "root"
+DEFAULT_PASS = ENV["MYSQL_PASS"]
+DEFAULT_SOCK = ENV["MYSQL_SOCK"] || "/tmp/mysql.sock"
+
+connect_options = {
+  path:     DEFAULT_SOCK, # for trilogy
+  socket:   DEFAULT_SOCK, # for mysql2
+  username: DEFAULT_USER,
+  password: DEFAULT_PASS,
+  host: "localhost",
+}
+
+Benchmark.ips do |x|
+  x.report "trilogy connect/close" do
+    client = Trilogy.new(connect_options)
+    client.close
+  end
+
+  x.report "mysql2 connect/close" do
+    client = Mysql2::Client.new(connect_options)
+    client.close
+  end
+
+  x.compare!
+end


### PR DESCRIPTION
```
$ script/benchmark-connect
Warming up --------------------------------------
trilogy connect/close
                       107.000  i/100ms
mysql2 connect/close   761.000  i/100ms
Calculating -------------------------------------
trilogy connect/close
                          1.022k (±73.3%) i/s -    321.000  in  19.716812s
mysql2 connect/close      7.564k (±19.0%) i/s -     37.289k in   5.246187s

Comparison:
mysql2 connect/close:     7564.4 i/s
trilogy connect/close:     1022.4 i/s - 7.40x  slower
```

I'll try to investigate, but opening now FYI