### PR TITLE
Ruby: Refactor Trilogy#initialize to make it easier to instrument connect

### DIFF
--- a/contrib/ruby/ext/trilogy-ruby/cext.c
+++ b/contrib/ruby/ext/trilogy-ruby/cext.c
@@ -425,7 +425,7 @@ static void authenticate(struct trilogy_ctx *ctx, trilogy_handshake_t *handshake
     }
 }
 
-static VALUE rb_trilogy_initialize(VALUE self, VALUE encoding, VALUE charset, VALUE opts)
+static VALUE rb_trilogy_connect(VALUE self, VALUE encoding, VALUE charset, VALUE opts)
 {
     struct trilogy_ctx *ctx = get_ctx(self);
     trilogy_sockopt_t connopt = {0};
@@ -436,7 +436,6 @@ static VALUE rb_trilogy_initialize(VALUE self, VALUE encoding, VALUE charset, VA
     connopt.encoding = NUM2INT(charset);
 
     Check_Type(opts, T_HASH);
-    rb_ivar_set(self, id_connection_options, opts);
 
     if ((val = rb_hash_lookup(opts, ID2SYM(id_ssl_mode))) != Qnil) {
         Check_Type(val, T_FIXNUM);
@@ -1104,7 +1103,7 @@ RUBY_FUNC_EXPORTED void Init_cext()
     VALUE Trilogy = rb_const_get(rb_cObject, rb_intern("Trilogy"));
     rb_define_alloc_func(Trilogy, allocate_trilogy);
 
-    rb_define_private_method(Trilogy, "_initialize", rb_trilogy_initialize, 3);
+    rb_define_private_method(Trilogy, "_connect", rb_trilogy_connect, 3);
     rb_define_method(Trilogy, "change_db", rb_trilogy_change_db, 1);
     rb_define_alias(Trilogy, "select_db", "change_db");
     rb_define_method(Trilogy, "query", rb_trilogy_query, 1);

--- a/contrib/ruby/lib/trilogy.rb
+++ b/contrib/ruby/lib/trilogy.rb
@@ -12,8 +12,10 @@ class Trilogy
     mysql_encoding = options[:encoding] || "utf8mb4"
     encoding = Trilogy::Encoding.find(mysql_encoding)
     charset = Trilogy::Encoding.charset(mysql_encoding)
+    @connection_options = options
+    @connected_host = nil
 
-    _initialize(encoding, charset, options)
+    _connect(encoding, charset, options)
   end
 
   def connection_options


### PR DESCRIPTION
This is mostly to allow things like https://github.com/open-telemetry/opentelemetry-ruby-contrib/pull/704 to be cleaner and more robust.

This way they can decorate `_connect` and access `@connection_options` without having to assign it themselves.