### PR TITLE
Fix minor typo in error.rb

### DIFF
--- a/contrib/ruby/lib/trilogy/error.rb
+++ b/contrib/ruby/lib/trilogy/error.rb
@@ -117,7 +117,7 @@ class Trilogy
     include ConnectionError
   end
 
-  # Occurrs when a socket read or write returns EOF or when an operation is
+  # Occurs when a socket read or write returns EOF or when an operation is
   # attempted on a socket which previously encountered an error.
   class EOFError < BaseConnectionError
   end


### PR DESCRIPTION
In one of the comments, "occurs" is slightly misspelled. This is a PR for that correction.