### PR TITLE
Fix Ruby version on CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,7 +24,7 @@ jobs:
             ruby: "1.9"
           - mysql: "5.7"
             distribution: "debian:buster"
-            ruby: "2.8"
+            ruby: "2.7"
     steps:
     - uses: actions/checkout@v4
     - name: docker login


### PR DESCRIPTION
Currently, Ruby version is specified unexist version(`2.8`). In this case, it seems that `ruby-build` use stable version(`3.2.2`). https://github.com/trilogy-libraries/trilogy/actions/runs/6646865109/job/18062157607#step:4:1205

But this pattern is already tested by other build. I assume this is just a typo of `2.7` that the last version of 2.x series.