### PR TITLE
Update README.md with caching_sha2_password limitation

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ It's currently in production use on github.com.
 
 * `trilogy_escape` assumes an ASCII-compatible connection encoding.
 
-* No support for the `caching_sha2_password` authentication plugin which is [the default for MySQL 8](https://dev.mysql.com/doc/refman/8.0/en/caching-sha2-pluggable-authentication.html). If your server uses it, you will receive a `trilogy_auth_recv: TRILOGY_UNEXPECTED_PACKET` error when authenticating with a password.
+* No support for `caching_sha2_password` in [MySQL 8](https://dev.mysql.com/doc/refman/8.0/en/caching-sha2-pluggable-authentication.html). Use `mysql_native_password` instead. When misconfigured, your application will raise `Trilogy::QueryError: trilogy_auth_recv: TRILOGY_UNEXPECTED_PACKET`.
 
 ## Building
 

--- a/README.md
+++ b/README.md
@@ -29,9 +29,11 @@ It's currently in production use on github.com.
 
 * Only supports the parts of the text protocol that are in common use.
 
-* No support for `LOAD DATA INFILE` on local files
+* No support for `LOAD DATA INFILE` on local files.
 
-* `trilogy_escape` assumes an ASCII-compatible connection encoding
+* `trilogy_escape` assumes an ASCII-compatible connection encoding.
+
+* No support for the `caching_sha2_password` authentication plugin. If your server uses it, you will receive a `trilogy_auth_recv: TRILOGY_UNEXPECTED_PACKET` error when authenticating with a password.
 
 ## Building
 

--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ It's currently in production use on github.com.
 
 * `trilogy_escape` assumes an ASCII-compatible connection encoding.
 
-* No support for the `caching_sha2_password` authentication plugin. If your server uses it, you will receive a `trilogy_auth_recv: TRILOGY_UNEXPECTED_PACKET` error when authenticating with a password.
+* No support for the `caching_sha2_password` authentication plugin which is [the default for MySQL 8](https://dev.mysql.com/doc/refman/8.0/en/caching-sha2-pluggable-authentication.html). If your server uses it, you will receive a `trilogy_auth_recv: TRILOGY_UNEXPECTED_PACKET` error when authenticating with a password.
 
 ## Building
 


### PR DESCRIPTION
Add caching_sha2_password limitation. I lost a lot of time trying to figure out why I couldn't authenticate and I think this should be in the README to save others in the future. Hopefully this will be fixed soon based on #26. 