### PR TITLE
Return rc from trilogy_sock_wait_write in connect

### DIFF
--- a/contrib/ruby/ext/trilogy-ruby/cext.c
+++ b/contrib/ruby/ext/trilogy-ruby/cext.c
@@ -577,9 +577,6 @@ static VALUE rb_trilogy_connect(VALUE self, VALUE encoding, VALUE charset, VALUE
     }
 
     int rc = try_connect(ctx, &handshake, &connopt);
-    if (rc == TRILOGY_TIMEOUT) {
-        rb_raise(Trilogy_TimeoutError, "trilogy_connect_recv");
-    }
     if (rc != TRILOGY_OK) {
         if (connopt.path) {
             handle_trilogy_error(ctx, rc, "trilogy_connect - unable to connect to %s", connopt.path);

--- a/src/socket.c
+++ b/src/socket.c
@@ -189,6 +189,7 @@ static int raw_connect_internal(struct trilogy_sock *sock, const struct addrinfo
 {
     int sockerr;
     socklen_t sockerr_len = sizeof(sockerr);
+    int rc = TRILOGY_SYSERR;
 
     sock->fd = socket(ai->ai_family, SOCK_STREAM, ai->ai_protocol);
     if (sock->fd < 0) {
@@ -244,8 +245,8 @@ static int raw_connect_internal(struct trilogy_sock *sock, const struct addrinfo
         }
     }
 
-    if (trilogy_sock_wait_write((trilogy_sock_t *)sock) < 0) {
-        goto fail;
+    if ((rc = trilogy_sock_wait_write((trilogy_sock_t *)sock)) < 0) {
+        goto failrc;
     }
 
     if (getsockopt(sock->fd, SOL_SOCKET, SO_ERROR, &sockerr, &sockerr_len) < 0) {
@@ -263,9 +264,11 @@ static int raw_connect_internal(struct trilogy_sock *sock, const struct addrinfo
     return TRILOGY_OK;
 
 fail:
+    rc = TRILOGY_SYSERR;
+failrc:
     close(sock->fd);
     sock->fd = -1;
-    return TRILOGY_SYSERR;
+    return rc;
 }
 
 static int _cb_raw_connect(trilogy_sock_t *_sock)


### PR DESCRIPTION
In `raw_connect_internal` we call `trilogy_sock_wait_write`, which will error if we don't connect within the specified `write_timeout`. Previously, we ignored the error code from trilogy_sock_wait_write and always returned `TRILOGY_SYSERR`.

This only changes the error class and message returned and doesn't otherwise affect timeout behaviour.

**Before:**

```
>> Trilogy.new(host: "198.51.100.1", write_timeout: 1)
lib/trilogy.rb:18:in `_connect': Operation now in progress - trilogy_connect - unable to connect to 198.51.100.1:3306 (Trilogy::SyscallError::EINPROGRESS)
```


**After:**

```
>> Trilogy.new(host: "198.51.100.1", write_timeout: 0.1)
lib/trilogy.rb:18:in `_connect': Connection timed out - trilogy_connect - unable to connect to 198.51.100.1:3306 (Trilogy::TimeoutError)
```