### PR TITLE
Error class revamp (part 2)

### DIFF
--- a/contrib/ruby/ext/trilogy-ruby/cext.c
+++ b/contrib/ruby/ext/trilogy-ruby/cext.c
@@ -91,7 +91,7 @@ NORETURN(static void trilogy_syserr_fail_str(int, VALUE));
 static void trilogy_syserr_fail_str(int e, VALUE msg)
 {
     if (e == EPIPE) {
-        // Backwards compatibility: This error class makes no sense, but matches legacy behavior
+        // Backwards compatibility: This error message is a bit odd, but includes "TRILOGY_CLOSED_CONNECTION" to match legacy string matching
         rb_raise(Trilogy_EOFError, "%" PRIsVALUE ": TRILOGY_CLOSED_CONNECTION: EPIPE", msg);
     } else {
         VALUE exc = rb_funcall(Trilogy_SyscallError, id_from_errno, 2, INT2NUM(e), msg);

--- a/contrib/ruby/ext/trilogy-ruby/cext.c
+++ b/contrib/ruby/ext/trilogy-ruby/cext.c
@@ -17,7 +17,7 @@
 
 VALUE Trilogy_CastError;
 static VALUE Trilogy_BaseConnectionError, Trilogy_ProtocolError, Trilogy_SSLError, Trilogy_QueryError,
-    Trilogy_ConnectionClosedError, Trilogy_ConnectionRefusedError, Trilogy_ConnectionResetError,
+    Trilogy_ConnectionClosedError,
     Trilogy_TimeoutError, Trilogy_SyscallError, Trilogy_Result, Trilogy_EOFError;
 
 static ID id_socket, id_host, id_port, id_username, id_password, id_found_rows, id_connect_timeout, id_read_timeout,
@@ -90,11 +90,7 @@ static struct trilogy_ctx *get_open_ctx(VALUE obj)
 NORETURN(static void trilogy_syserr_fail_str(int, VALUE));
 static void trilogy_syserr_fail_str(int e, VALUE msg)
 {
-    if (e == ECONNREFUSED) {
-        rb_raise(Trilogy_ConnectionRefusedError, "%" PRIsVALUE, msg);
-    } else if (e == ECONNRESET) {
-        rb_raise(Trilogy_ConnectionResetError, "%" PRIsVALUE, msg);
-    } else if (e == EPIPE) {
+    if (e == EPIPE) {
         // Backwards compatibility: This error class makes no sense, but matches legacy behavior
         rb_raise(Trilogy_EOFError, "%" PRIsVALUE ": TRILOGY_CLOSED_CONNECTION: EPIPE", msg);
     } else {
@@ -1157,12 +1153,6 @@ RUBY_FUNC_EXPORTED void Init_cext()
 
     Trilogy_TimeoutError = rb_const_get(Trilogy, rb_intern("TimeoutError"));
     rb_global_variable(&Trilogy_TimeoutError);
-
-    Trilogy_ConnectionRefusedError = rb_const_get(Trilogy, rb_intern("ConnectionRefusedError"));
-    rb_global_variable(&Trilogy_ConnectionRefusedError);
-
-    Trilogy_ConnectionResetError = rb_const_get(Trilogy, rb_intern("ConnectionResetError"));
-    rb_global_variable(&Trilogy_ConnectionResetError);
 
     Trilogy_BaseConnectionError = rb_const_get(Trilogy, rb_intern("BaseConnectionError"));
     rb_global_variable(&Trilogy_BaseConnectionError);

--- a/contrib/ruby/lib/trilogy/error.rb
+++ b/contrib/ruby/lib/trilogy/error.rb
@@ -12,7 +12,7 @@ class Trilogy
   end
 
   # Trilogy may raise various syscall errors, which we treat as Trilogy::Errors.
-  class SyscallError
+  module SyscallError
     ERRORS = {}
 
     Errno.constants
@@ -20,7 +20,10 @@ class Trilogy
       .select { |c| c.is_a?(Class) && c < SystemCallError }
       .each do |c|
         errno_name = c.to_s.split('::').last
-        ERRORS[c::Errno] = const_set(errno_name, Class.new(c) { include Trilogy::ConnectionError })
+        ERRORS[c::Errno] = const_set(errno_name, Class.new(c) {
+          include Trilogy::ConnectionError
+          singleton_class.define_method(:===, Module.instance_method(:===))
+        })
       end
 
     ERRORS.freeze

--- a/contrib/ruby/lib/trilogy/error.rb
+++ b/contrib/ruby/lib/trilogy/error.rb
@@ -32,6 +32,11 @@ class Trilogy
     end
   end
 
+  ConnectionRefusedError = SyscallError::ECONNREFUSED
+  deprecate_constant :ConnectionRefusedError
+  ConnectionResetError = SyscallError::ECONNRESET
+  deprecate_constant :ConnectionResetError
+
   class BaseError < StandardError
     include Error
 
@@ -65,14 +70,6 @@ class Trilogy
       super
       @error_code = error_code
     end
-  end
-
-  class ConnectionRefusedError < Errno::ECONNREFUSED
-    include ConnectionError
-  end
-
-  class ConnectionResetError < Errno::ECONNRESET
-    include ConnectionError
   end
 
   # DatabaseError was replaced by ProtocolError, but we'll keep it around as an

--- a/contrib/ruby/lib/trilogy/error.rb
+++ b/contrib/ruby/lib/trilogy/error.rb
@@ -66,13 +66,7 @@ class Trilogy
   class CastError < ClientError
   end
 
-  class TimeoutError < Errno::ETIMEDOUT
-    include ConnectionError
-
-    def initialize(error_message = nil, error_code = nil)
-      super
-      @error_code = error_code
-    end
+  class TimeoutError < BaseConnectionError
   end
 
   # DatabaseError was replaced by ProtocolError, but we'll keep it around as an

--- a/contrib/ruby/test/client_test.rb
+++ b/contrib/ruby/test/client_test.rb
@@ -1099,4 +1099,14 @@ class ClientTest < TrilogyTest
 
     assert client.query("SELECT 1")
   end
+
+  def test_error_classes_exclusively_match_subclasses
+    klass = Trilogy::SyscallError::ECONNRESET
+    assert_operator klass, :===, klass.new
+    refute_operator klass, :===, Errno::ECONNRESET.new
+
+    assert_operator Errno::ECONNRESET, :===, klass.new
+    assert_operator SystemCallError, :===, klass.new
+    assert_operator Trilogy::ConnectionError, :===, klass.new
+  end
 end

--- a/contrib/ruby/test/client_test.rb
+++ b/contrib/ruby/test/client_test.rb
@@ -42,7 +42,9 @@ class ClientTest < TrilogyTest
 
     socket = new_tcp_client.query("SHOW VARIABLES LIKE 'socket'").to_a[0][1]
 
-    assert File.exist?(socket), "cound not find socket at #{socket}"
+    if !File.exist?(socket)
+      skip "cound not find socket at #{socket}"
+    end
 
     client = new_unix_client(socket)
     refute_nil client


### PR DESCRIPTION
@composerinteralia and I paired on making another pass over the errors. Partly inspired by complexities revealed in https://github.com/rails/rails/pull/50202

The most significant change is that this redefines `===` on our custom `SystemCallError` descendants to use the standard `Module#===` implementation. Without this they are hard to check for specifically because the Errno classes redefine `===` to make anything which responds to `errno` and returns the same one equal. As suggested by @byroot in https://github.com/rails/rails/pull/50202#discussion_r1408359465

This also removes the inheritance of `Trilogy::TimeoutError` from `Errno::ETIMEDOUT`, as that represents a timeout we have declared after waiting rather than an I/O timeout the kernel/stdlib is informing us about.

Lastly this deprecates `Trilogy::ConnectionRefusedError` and `Trilogy::ConnectionResetError`, replacing them with `Trilogy::SyscallError::ECONNREFUSED` and `Trilogy::SyscallError::ECONNRESET` (and making them aliases). This avoids having duplicate errors representing the same thing and makes all our "errno" errors share common implementation 😌. As a bonus this removes some C and replaces it with Ruby.

I think this makes some good progress in making errors easier to handle, but I do anticipate making at least a "part 3" 😅.

cc @adrianna-chang-shopify @matthewd 