### PR TITLE
Plug memory leaks from failed connections

### DIFF
--- a/contrib/ruby/ext/trilogy-ruby/extconf.rb
+++ b/contrib/ruby/ext/trilogy-ruby/extconf.rb
@@ -2,8 +2,12 @@ require "mkmf"
 
 # concatenate trilogy library sources to allow the compiler to optimise across
 # source files
+
+trilogy_src_dir = File.realpath("src", __dir__)
 File.binwrite("trilogy.c",
-  Dir["#{__dir__}/src/**/*.c"].map { |src| File.binread(src) }.join)
+  Dir["#{trilogy_src_dir}/**/*.c"].map { |src|
+    %{#line 1 "#{src}"\n} + File.binread(src)
+  }.join)
 
 $objs = %w[trilogy.o cast.o cext.o]
 $CFLAGS << " -I #{__dir__}/inc -std=gnu99 -fvisibility=hidden"

--- a/src/buffer.c
+++ b/src/buffer.c
@@ -57,4 +57,9 @@ int trilogy_buffer_putc(trilogy_buffer_t *buffer, uint8_t c)
     return TRILOGY_OK;
 }
 
-void trilogy_buffer_free(trilogy_buffer_t *buffer) { free(buffer->buff); }
+void trilogy_buffer_free(trilogy_buffer_t *buffer)
+{
+    free(buffer->buff);
+    buffer->buff = NULL;
+    buffer->len = buffer->cap = 0;
+}


### PR DESCRIPTION
Under a couple conditions we could leak the internal `buffer->buff` buffer or a `trilogy_sock_t` before it was attached to the client.

These were found using `RUBY_FREE_AT_EXIT=1` and ASAN/LSAN.

I made it supported to call `trilogy_free` multiple times on the same connection.