### PR TITLE
Return false instead of raising an error when connection is lost in Trilogy#ping method

### DIFF
--- a/contrib/ruby/ext/trilogy-ruby/cext.c
+++ b/contrib/ruby/ext/trilogy-ruby/cext.c
@@ -913,7 +913,11 @@ static VALUE rb_trilogy_query(VALUE self, VALUE query)
 
 static VALUE rb_trilogy_ping(VALUE self)
 {
-    struct trilogy_ctx *ctx = get_open_ctx(self);
+    struct trilogy_ctx *ctx = get_ctx(self);
+
+    if (ctx->conn.socket == NULL) {
+        return Qfalse;
+    }
 
     int rc = trilogy_ping_send(&ctx->conn);
 
@@ -922,7 +926,7 @@ static VALUE rb_trilogy_ping(VALUE self)
     }
 
     if (rc < 0) {
-        handle_trilogy_error(ctx, rc, "trilogy_ping_send");
+        return Qfalse;
     }
 
     while (1) {
@@ -933,12 +937,12 @@ static VALUE rb_trilogy_ping(VALUE self)
         }
 
         if (rc != TRILOGY_AGAIN) {
-            handle_trilogy_error(ctx, rc, "trilogy_ping_recv");
+            return Qfalse;
         }
 
         rc = trilogy_sock_wait_read(ctx->conn.socket);
         if (rc != TRILOGY_OK) {
-            handle_trilogy_error(ctx, rc, "trilogy_ping_recv");
+            return Qfalse;
         }
     }
 

--- a/contrib/ruby/test/client_test.rb
+++ b/contrib/ruby/test/client_test.rb
@@ -80,11 +80,20 @@ class ClientTest < TrilogyTest
 
   def test_trilogy_ping_after_close_returns_false
     client = new_tcp_client
-    assert client.ping
+    assert_equal client.ping, true
     client.close
-    assert_raises Trilogy::ConnectionClosed do
-      client.ping
+    assert_equal client.ping, false
+  ensure
+    ensure_closed client
+  end
+
+  def test_trilogy_ping_after_connection_closed_returns_false
+    client = new_tcp_client(read_timeout: 1)
+    assert_equal client.ping, true
+    assert_raises Trilogy::TimeoutError do
+      client.query("SELECT SLEEP (2)")
     end
+    assert_equal client.ping, false
   ensure
     ensure_closed client
   end

--- a/contrib/ruby/test/client_test.rb
+++ b/contrib/ruby/test/client_test.rb
@@ -580,7 +580,7 @@ class ClientTest < TrilogyTest
     assert_equal "Invalid date: 1234-00-00 00:00:00", err.message
 
     assert_raises_connection_error do
-      client.ping
+      client.query("SELECT 1")
     end
   end
 
@@ -692,7 +692,7 @@ class ClientTest < TrilogyTest
     end
 
     assert_raises_connection_error do
-      client.ping
+      client.query("SELECT 1")
     end
   end
 
@@ -850,7 +850,7 @@ class ClientTest < TrilogyTest
     refute_match(/TRILOGY_MAX_PACKET_EXCEEDED/, exception.message)
 
     assert_raises_connection_error do
-      client.ping
+      client.query("SELECT 1")
     end
   ensure
     ensure_closed client


### PR DESCRIPTION
This pull request modifies the behavior of the `Trilogy#ping` method. Now, it returns `false` instead of raising an error when the connection is lost. This change will help users handle connection loss more gracefully and avoid unnecessary exceptions.

The test case `test_trilogy_ping_after_close_returns_false` suggests the original intention was to return false when the connection is lost.
Additionally, `Mysql2::Client#ping` returns false instead of raising an error when the connection is lost. If Trilogy adopts the same behavior, it would make it easier for users to switch between the two libraries.

Furthermore, this change is expected to work without any issues in the trilogy_adapter of Rails, as `Trilogy#ping` method is only used in the following method:
https://github.com/rails/rails/blob/dca72dab117e79ee75666927935a7a6a31dd5324/activerecord/lib/active_record/connection_adapters/trilogy_adapter.rb#L120-L124