### PR TITLE
Fix Docker build args for CI matrix; remove Ruby 1.9 tests; change base option to Ruby 3.3

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,14 +17,11 @@ jobs:
       matrix:
         mysql: ["5.7", "8"]
         distribution: ["debian:buster", "ubuntu:focal", "ubuntu:bionic"]
-        ruby: ["3.2"]
+        ruby: ["3.3"]
         include:
           - mysql: "5.7"
             distribution: "debian:buster"
-            ruby: "1.9"
-          - mysql: "5.7"
-            distribution: "debian:buster"
-            ruby: "2.8"
+            ruby: "2.7.8"
     steps:
     - uses: actions/checkout@v4
     - name: docker login

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,4 @@
 ARG DISTRIBUTION=ubuntu:jammy
-ARG RUBY_VERSION=3.2
 FROM ${DISTRIBUTION}
 LABEL maintainer="github@github.com"
 
@@ -10,9 +9,10 @@ RUN update-ca-certificates
 RUN wget https://github.com/postmodern/ruby-install/releases/download/v0.9.0/ruby-install-0.9.0.tar.gz && \
     tar -xzvf ruby-install-0.9.0.tar.gz && \
     cd ruby-install-0.9.0/ && \
-    make install && \
-    ruby-install --system ruby ${RUBY_VERSION}
+    make install
 
+ARG RUBY_VERSION=3.2
+RUN ruby-install --system ruby ${RUBY_VERSION}
 RUN ruby --version
 
 WORKDIR /app


### PR DESCRIPTION
Fixes #137

I couldn't find a working formula for Ruby 1.9. 