### PR TITLE
Update mysql2 to a version that can compile with MySQL 8.3.

### DIFF
--- a/contrib/ruby/Gemfile.lock
+++ b/contrib/ruby/Gemfile.lock
@@ -8,7 +8,7 @@ GEM
   specs:
     benchmark-ips (2.7.2)
     minitest (5.11.3)
-    mysql2 (0.5.5)
+    mysql2 (0.5.6)
     rake (13.0.1)
     rake-compiler (1.0.7)
       rake


### PR DESCRIPTION
_mysql2_ 0.5.6 was released with a fix for a [compliation issue with MySQL 8.3](https://github.com/brianmario/mysql2/issues/1346). While it can be worked around by installing older MySQL client libraries, bumping the gem would obviate the need for doing so.