### PR TITLE
Rename test for `Trilogy#ping`

### DIFF
--- a/contrib/ruby/test/client_test.rb
+++ b/contrib/ruby/test/client_test.rb
@@ -80,7 +80,7 @@ class ClientTest < TrilogyTest
     ensure_closed client
   end
 
-  def test_trilogy_ping_after_close_returns_raises
+  def test_trilogy_ping_after_close_raises
     client = new_tcp_client
     assert client.ping
     client.close

--- a/contrib/ruby/test/client_test.rb
+++ b/contrib/ruby/test/client_test.rb
@@ -80,7 +80,7 @@ class ClientTest < TrilogyTest
     ensure_closed client
   end
 
-  def test_trilogy_ping_after_close_returns_false
+  def test_trilogy_ping_after_close_returns_raises
     client = new_tcp_client
     assert client.ping
     client.close


### PR DESCRIPTION
I renamed `test_trilogy_ping_after_close_returns_false` to `test_trilogy_ping_after_close_raises` to more accurately reflect its content as discussed here: https://github.com/trilogy-libraries/trilogy/pull/145#issuecomment-1880418956.