### PR TITLE
Implement caching_sha2_password for mysql 8+

### DIFF
--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -6,7 +6,7 @@ on:
     tags:
       - v*
   pull_request:
-    
+
 jobs:
   test:
     name: Test
@@ -36,12 +36,15 @@ jobs:
     steps:
     - uses: actions/checkout@v4
     - name: Setup MySQL
+      env:
+        MYSQL_VERSION: ${{ matrix.mysql }}
       run: |
         brew install mysql@${{ matrix.mysql }}
         (unset CI; brew postinstall mysql@${{ matrix.mysql }})
         brew services start mysql@${{ matrix.mysql }}
         sleep 5
         $(brew --prefix mysql@${{ matrix.mysql }})/bin/mysql -uroot -e 'CREATE DATABASE test'
+        [[ "$MYSQL_VERSION" == "8.0" ]] && $(brew --prefix mysql@${{ matrix.mysql }})/bin/mysql -uroot < docker-entrypoint-initdb.d/caching_sha2_password_user.sql
         $(brew --prefix mysql@${{ matrix.mysql }})/bin/mysql -uroot < docker-entrypoint-initdb.d/native_password_user.sql
         $(brew --prefix mysql@${{ matrix.mysql }})/bin/mysql -uroot < docker-entrypoint-initdb.d/x509_user.sql
     - name: Install dependencies

--- a/contrib/ruby/ext/trilogy-ruby/cext.c
+++ b/contrib/ruby/ext/trilogy-ruby/cext.c
@@ -156,6 +156,10 @@ static void handle_trilogy_error(struct trilogy_ctx *ctx, int rc, const char *ms
         rb_raise(Trilogy_EOFError, "%" PRIsVALUE ": TRILOGY_CLOSED_CONNECTION", rbmsg);
     }
 
+    case TRILOGY_UNSUPPORTED: {
+        rb_raise(Trilogy_BaseConnectionError, "%" PRIsVALUE ": TRILOGY_UNSUPPORTED", rbmsg);
+    }
+
     default:
         rb_raise(Trilogy_QueryError, "%" PRIsVALUE ": %s", rbmsg, trilogy_error(rc));
     }
@@ -419,7 +423,12 @@ static void authenticate(struct trilogy_ctx *ctx, trilogy_handshake_t *handshake
         }
 
         if (rc != TRILOGY_AGAIN) {
-            handle_trilogy_error(ctx, rc, "trilogy_auth_recv");
+            if (rc == TRILOGY_UNSUPPORTED) {
+                handle_trilogy_error(ctx, rc, "trilogy_auth_recv: caching_sha2_password requires either TCP with TLS or a unix socket");
+            }
+            else {
+                handle_trilogy_error(ctx, rc, "trilogy_auth_recv");
+            }
         }
 
         rc = trilogy_sock_wait_read(ctx->conn.socket);

--- a/contrib/ruby/test/client_test.rb
+++ b/contrib/ruby/test/client_test.rb
@@ -49,6 +49,45 @@ class ClientTest < TrilogyTest
     ensure_closed client
   end
 
+  def test_connect_with_unix_and_caching_sha2_works
+    return skip unless has_caching_sha2?
+    return skip unless ["127.0.0.1", "localhost"].include?(DEFAULT_HOST)
+
+    socket = new_tcp_client.query("SHOW VARIABLES LIKE 'socket'").to_a[0][1]
+
+    if !File.exist?(socket)
+      skip "cound not find socket at #{socket}"
+    end
+
+    client = new_unix_client(socket, username: "caching_sha2", password: "password")
+    refute_nil client
+  ensure
+    ensure_closed client
+  end
+
+  def test_connect_without_ssl_or_unix_socket_caching_sha2_raises
+    return skip unless has_caching_sha2?
+
+    # Ensure correct setup
+    assert_equal [["caching_sha2_password"]], new_tcp_client.query("SELECT plugin FROM mysql.user WHERE user = 'caching_sha2'").rows
+
+    options = {
+      host: DEFAULT_HOST,
+      port: DEFAULT_PORT,
+      username: "caching_sha2",
+      password: "password",
+      ssl: false,
+      ssl_mode: 0
+    }
+
+    err = assert_raises Trilogy::ConnectionError do
+      new_tcp_client options
+    end
+
+    assert_includes err.message, "TRILOGY_UNSUPPORTED"
+    assert_includes err.message, "caching_sha2_password requires either TCP with TLS or a unix socket"
+  end
+
   def test_connection_error_native
     err = assert_raises Trilogy::ConnectionError do
       new_tcp_client(username: "native", password: "incorrect")

--- a/contrib/ruby/test/client_test.rb
+++ b/contrib/ruby/test/client_test.rb
@@ -30,6 +30,13 @@ class ClientTest < TrilogyTest
     ensure_closed client
   end
 
+  def test_trilogy_connect_with_caching_sha2_password_auth_switch
+    client = new_tcp_client username: "caching_sha2", password: "password"
+    refute_nil client
+  ensure
+    ensure_closed client
+  end
+
   def test_trilogy_connect_tcp_to_wrong_port
     e = assert_raises Trilogy::ConnectionError do
       new_tcp_client port: 13307

--- a/docker-entrypoint-initdb.d/caching_sha2_password_user.sql
+++ b/docker-entrypoint-initdb.d/caching_sha2_password_user.sql
@@ -1,0 +1,3 @@
+CREATE USER 'caching_sha2'@'%';
+GRANT ALL PRIVILEGES ON test.* TO 'caching_sha2'@'%';
+ALTER USER 'caching_sha2'@'%' IDENTIFIED WITH caching_sha2_password BY 'password';

--- a/docker-entrypoint-initdb.d/caching_sha2_password_user.sql
+++ b/docker-entrypoint-initdb.d/caching_sha2_password_user.sql
@@ -1,3 +1,3 @@
 CREATE USER 'caching_sha2'@'%';
 GRANT ALL PRIVILEGES ON test.* TO 'caching_sha2'@'%';
-ALTER USER 'caching_sha2'@'%' IDENTIFIED WITH caching_sha2_password BY 'password';
+ALTER USER 'caching_sha2'@'%' IDENTIFIED /*!80000 WITH caching_sha2_password */ BY 'password';

--- a/inc/trilogy/protocol.h
+++ b/inc/trilogy/protocol.h
@@ -367,6 +367,7 @@ typedef enum {
 // Typical response packet types
 typedef enum {
     TRILOGY_PACKET_OK = 0x0,
+    TRILOGY_PACKET_AUTH_MORE_DATA = 0x01,
     TRILOGY_PACKET_EOF = 0xfe,
     TRILOGY_PACKET_ERR = 0xff,
     TRILOGY_PACKET_UNKNOWN
@@ -1034,5 +1035,7 @@ int trilogy_parse_stmt_ok_packet(const uint8_t *buff, size_t len, trilogy_stmt_o
  */
 int trilogy_parse_stmt_row_packet(const uint8_t *buff, size_t len, trilogy_column_packet_t *columns,
                                   uint64_t column_count, trilogy_binary_value_t *out_values);
+
+int trilogy_build_auth_clear_password(trilogy_builder_t *builder, const char *pass, size_t pass_len);
 
 #endif

--- a/src/client.c
+++ b/src/client.c
@@ -420,6 +420,13 @@ int trilogy_auth_recv(trilogy_conn_t *conn, trilogy_handshake_t *handshake)
 
     switch (current_packet_type(conn)) {
     case TRILOGY_PACKET_AUTH_MORE_DATA: {
+        bool use_ssl = (conn->socket->opts.flags & TRILOGY_CAPABILITIES_SSL) != 0;
+        bool has_unix_socket = (conn->socket->opts.path != NULL);
+
+        if (!use_ssl && !has_unix_socket) {
+            return TRILOGY_UNSUPPORTED;
+        }
+
         uint8_t byte = conn->packet_buffer.buff[1];
         switch (byte) {
             case FAST_AUTH_OK:

--- a/src/protocol.c
+++ b/src/protocol.c
@@ -593,7 +593,16 @@ int trilogy_build_auth_packet(trilogy_builder_t *builder, const char *user, cons
 
     trilogy_builder_finalize(builder);
 
-    return TRILOGY_OK;
+fail:
+    return rc;
+}
+
+int trilogy_build_auth_clear_password(trilogy_builder_t *builder, const char *pass, size_t pass_len) {
+    int rc = TRILOGY_OK;
+
+    CHECKED(trilogy_builder_write_buffer(builder, pass, pass_len));
+    CHECKED(trilogy_builder_write_uint8(builder, 0));
+    trilogy_builder_finalize(builder);
 
 fail:
     return rc;


### PR DESCRIPTION
This PR implements caching_sha2_password for mysql 8. Note that we have
chosen on purpose to only implement the path where TLS or a unix socket is used. We will
not be implementing the non-TLS/non-unix socket path.
    
Co-authored-by: John Hawthorn <john@hawthorn.email>
Co-authored-by: Aaron Patterson (tenderlove) <tenderlove@ruby-lang.org>

Fixes: https://github.com/trilogy-libraries/trilogy/issues/26

---

**For testing:**

Point trilogy at this branch in your Gemfile:

```ruby
gem "trilogy", github: "trilogy-libraries/trilogy", branch: "caching_sha2_password", glob: "contrib/ruby/*.gemspec"
```

Update your mysql auth plugin / policy to use `caching_sha2_password` over `mysql_native_password`