### PR TITLE
Remove version from docker-compose.yml

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,4 +1,3 @@
-version: "3.5"
 services:
   db:
     platform: linux/x86_64


### PR DESCRIPTION
Now that we're on `docker compose` (v2), the `version` declaration in `docker-compose.yml` is obsolete. This removes the following warning when running `script/cibuild`:

```
WARN[0000] /Users/ngan/Development/trilogy/docker-compose.yml: `version` is obsolete
```