### PR TITLE
Point mysql to certs instead of copying them

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -8,6 +8,9 @@ services:
       - --gtid-mode=ON
       - --enforce-gtid-consistency=ON
       - --log-bin=mysql-bin.log
+      - --ssl-ca=/mysql-certs/ca.pem
+      - --ssl-cert=/mysql-certs/server-cert.pem
+      - --ssl-key=/mysql-certs/server-key.pem
     build:
       context: .
       dockerfile: Dockerfile.mysql

--- a/docker-entrypoint-initdb.d/generate_keys.sh
+++ b/docker-entrypoint-initdb.d/generate_keys.sh
@@ -2,7 +2,7 @@
 
 set -euo pipefail
 
-cd /var/lib/mysql
+cd /mysql-certs
 
 # Generate a CA to test with
 
@@ -53,8 +53,3 @@ openssl x509 -req -sha256 -CA ca.pem -CAkey ca-key.pem -set_serial 2 \
     -days 365 \
     -in  client-csr.pem \
     -out client-cert.pem
-
-# Copy the certificates to the shared directory so that it's accessible from the app
-# container.
-
-cp /var/lib/mysql/*.pem /mysql-certs

--- a/script/cibuild
+++ b/script/cibuild
@@ -35,6 +35,7 @@ output_fold() {
 function cleanup() {
   echo
   echo "::group::Shutting down services..."
+  docker compose logs db
   docker compose down --volumes
   echo "::endgroup::"
 }


### PR DESCRIPTION
In https://github.com/trilogy-libraries/trilogy/pull/175, I made it so that the certs were copied from `/var/lib/mysql/*.pem` into `/mysql-certs/*`. This felt awkward at the time but I wanted to defer the fix since it wasn't that important. I'm revisit this now and in this PR, we're going to tell mysql where to find the certificates instead.

This means that we now generate the certificates directly into `/mysql-certs/*` -- so no more copying!