### PR TITLE
Clear password without memset

### DIFF
--- a/script/cibuild
+++ b/script/cibuild
@@ -55,7 +55,7 @@ export DISTRIBUTION_SLUG
 # and chmod this directory on the host so that the permissions are persisted when the
 # the directory is mounted in the containers. Since the mysql container runs as a non-root
 # user, we need to ensure that the directory is writable by all users.
-mkdir tmp/mysql-certs
+mkdir -p tmp/mysql-certs
 chmod 777 tmp/mysql-certs
 
 docker compose rm --stop --force --volumes

--- a/src/client.c
+++ b/src/client.c
@@ -404,7 +404,12 @@ int trilogy_auth_switch_send(trilogy_conn_t *conn, const trilogy_handshake_t *ha
 void trilogy_auth_clear_password(trilogy_conn_t *conn)
 {
     if (conn->socket->opts.password) {
-        memset(conn->socket->opts.password, 0, conn->socket->opts.password_len);
+        volatile char *password_ptr = (volatile char*)(conn->socket->opts.password);
+        while (conn->socket->opts.password_len--) {
+            *password_ptr++ = 0;
+        }
+        free(conn->socket->opts.password);
+        conn->socket->opts.password = NULL;
     }
 }
 


### PR DESCRIPTION
Fixes https://github.com/trilogy-libraries/trilogy/issues/103
Closes https://github.com/trilogy-libraries/trilogy/pull/182

Instead of using `memset()` to clear the password, clear the password byte by byte in a loop. Additionally, we mark the `char*` as `volatile` to ensure that the compiler does not optimize away the memory access or the clearing operation.