### PR TITLE
Add changelog entry for #184

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,10 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/).
 
 ## Unreleased
 
+### Fixed
+
+- Fix "Got packets our of order" errors on connect. #184
+
 ## 2.8.0
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/).
 
 ### Fixed
 
-- Fix "Got packets our of order" errors on connect. #184
+- Fix "Got packets out of order" errors on connect. #184
 
 ## 2.8.0
 


### PR DESCRIPTION
The changelog entry was missing for #184, which fixes broken sequencing that we were seeing in some cases.