### PR TITLE
Add rbmsg back to TRILOGY_ERR

### DIFF
--- a/contrib/ruby/ext/trilogy-ruby/cext.c
+++ b/contrib/ruby/ext/trilogy-ruby/cext.c
@@ -133,7 +133,8 @@ static void handle_trilogy_error(struct trilogy_ctx *ctx, int rc, const char *ms
         rb_raise(Trilogy_TimeoutError, "%" PRIsVALUE, rbmsg);
 
     case TRILOGY_ERR: {
-        VALUE message = rb_str_new(ctx->conn.error_message, ctx->conn.error_message_len);
+        VALUE conn_message = rb_str_new(ctx->conn.error_message, ctx->conn.error_message_len);
+        VALUE message = rb_sprintf("%" PRIsVALUE " (%" PRIsVALUE ")", conn_message, rbmsg);
         VALUE exc = rb_funcall(Trilogy_ProtocolError, id_from_code, 2, message, INT2NUM(ctx->conn.error_code));
         rb_exc_raise(exc);
     }

--- a/contrib/ruby/test/client_test.rb
+++ b/contrib/ruby/test/client_test.rb
@@ -270,6 +270,7 @@ class ClientTest < TrilogyTest
 
     assert_instance_of(Trilogy::ProtocolError, e)
     assert_match(/1047: Unknown command/, e.message)
+    assert_match(/trilogy_set_option_recv/, e.message)
   end
 
   def test_trilogy_set_server_option_multi_statement
@@ -283,6 +284,7 @@ class ClientTest < TrilogyTest
 
     assert_instance_of(Trilogy::QueryError, e)
     assert_match(/1064: You have an error in your SQL syntax/, e.message)
+    assert_match(/trilogy_query_recv/, e.message)
 
     client.set_server_option(Trilogy::SET_SERVER_MULTI_STATEMENTS_ON)
     client.query("INSERT INTO trilogy_test (int_test) VALUES ('4'); INSERT INTO trilogy_test (int_test) VALUES ('1')")
@@ -301,6 +303,7 @@ class ClientTest < TrilogyTest
 
     assert_instance_of(Trilogy::QueryError, e)
     assert_match(/1064: You have an error in your SQL syntax/, e.message)
+    assert_match(/trilogy_query_recv/, e.message)
   end
 
   def test_trilogy_query_result_object


### PR DESCRIPTION
This was previously [removed][1] when error classes were refactored, but it doesn't seem to have been done so intentionally.

When debugging a previous [fix][2], this missing context would have helped narrow down the problem initially as the rbmsg includes where the error was originating.

[1]: https://github.com/trilogy-libraries/trilogy/commit/f9ee855543de22d9b2e5a3714439458ade2e1717
[2]: https://github.com/trilogy-libraries/trilogy/commit/cb788be650d2f85502f5728c5fb3b287eb1f9313