### PR TITLE
Add tasks to drop and create test database

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -15,6 +15,9 @@ Please note that this project is released with a [Contributor Code of Conduct](C
 0. Build it and make sure the tests pass on your machine: `script/cibuild`. It will run both trilogy and ruby bindings suites in docker environment.
  
     To shorten the development loop you can:
+
+    > [!TIP]
+    > If you haven't already, you will need to create a database named `test`.
      
     a) run trilogy tests locally with: `make test`  
     b) run ruby binding tests with `cd contrib/ruby`, `bundle exec rake test`. It's possible to run a test single example by passing a `TESTOPTS` environment variable like so: `TESTOPTS=-n/test_packet_size_greater_than_trilogy_max_packet_len/`.

--- a/contrib/ruby/Rakefile
+++ b/contrib/ruby/Rakefile
@@ -19,10 +19,25 @@ Rake::TestTask.new do |t|
   t.test_files = FileList['test/*_test.rb']
   t.verbose = true
 end
-task :test => :compile
+
+task :test => [:compile, "db:clean"]
 
 task :default => :test
 
 task :console => :compile do
   sh "ruby -I lib -r trilogy -S irb"
 end
+
+namespace :db do
+  task :create do
+    mysql_command = "mysql -uroot -e"
+    %x( #{mysql_command} "create DATABASE IF NOT EXISTS test DEFAULT CHARACTER SET utf8mb4" )
+  end
+
+  task :drop do
+    mysql_command = "mysql -uroot -e"
+    %x( #{mysql_command} "drop DATABASE IF EXISTS test" )
+  end
+
+  task :clean => ["db:drop", "db:create"]
+end 


### PR DESCRIPTION
In the `CONTRIBUTING.md` it says

> To shorten the development loop you can:
>
> a) run trilogy tests locally with: make test
> b) run ruby binding tests with cd contrib/ruby, bundle exec rake test. It's possible to run a test single example by passing a TESTOPTS environment variable like so: TESTOPTS=-n/test_packet_size_greater_than_trilogy_max_packet_len/.

When you follow these instructions, it will fail if you do not have a `test` database created. This change adds tasks the following tasks:

- `db:create`
- `db:drop`
- `db:clean`

When running the ruby binding tests, it will run the `db:clean` task to drop the test database first (if it exists) and creates it.

I think it will also be helpful to have a similar task in the `Makefile` so that `make test` can setup the DB if the user chooses not to use the docker approach. However, I am not sure how to do this 🤔

It might also be useful to push forward with
https://github.com/trilogy-libraries/trilogy/issues/170 as we can pontentially move away from Docker for the CI builds.