### PR TITLE
Add `last_result_size` to ruby connection

### DIFF
--- a/contrib/ruby/ext/trilogy-ruby/cext.c
+++ b/contrib/ruby/ext/trilogy-ruby/cext.c
@@ -1131,6 +1131,8 @@ static VALUE rb_trilogy_server_status(VALUE self) { return LONG2FIX(get_open_ctx
 
 static VALUE rb_trilogy_server_version(VALUE self) { return rb_str_new_cstr(get_open_ctx(self)->server_version); }
 
+static VALUE rb_trilogy_last_result_size(VALUE self) { return rb_int_new(get_open_ctx(self)->conn.recv_buff_len); }
+
 RUBY_FUNC_EXPORTED void Init_cext(void)
 {
     VALUE Trilogy = rb_const_get(rb_cObject, rb_intern("Trilogy"));
@@ -1161,6 +1163,7 @@ RUBY_FUNC_EXPORTED void Init_cext(void)
     rb_define_method(Trilogy, "more_results_exist?", rb_trilogy_more_results_exist, 0);
     rb_define_method(Trilogy, "next_result", rb_trilogy_next_result, 0);
     rb_define_method(Trilogy, "set_server_option", rb_trilogy_set_server_option, 1);
+    rb_define_method(Trilogy, "last_result_size", rb_trilogy_last_result_size, 0);
     rb_define_const(Trilogy, "TLS_VERSION_10", INT2NUM(TRILOGY_TLS_VERSION_10));
     rb_define_const(Trilogy, "TLS_VERSION_11", INT2NUM(TRILOGY_TLS_VERSION_11));
     rb_define_const(Trilogy, "TLS_VERSION_12", INT2NUM(TRILOGY_TLS_VERSION_12));

--- a/contrib/ruby/test/client_test.rb
+++ b/contrib/ruby/test/client_test.rb
@@ -272,6 +272,20 @@ class ClientTest < TrilogyTest
     assert_match(/1047: Unknown command/, e.message)
   end
 
+  def test_trilogy_last_result_size
+    client = new_tcp_client
+    create_test_table(client)
+
+    client.query("INSERT INTO trilogy_test (int_test) VALUES ('4')")
+    client.query("INSERT INTO trilogy_test (int_test) VALUES ('3')")
+
+    result = client.query("SELECT id, int_test FROM trilogy_test")
+    result_size = client.last_result_size
+
+    assert_equal [1, 4, 2, 3], result.rows.flatten
+    assert_includes 150..170, result_size, "Expected last_result_size to be between 150 and 170, but was #{result_size}"
+  end
+
   def test_trilogy_set_server_option_multi_statement
     # Start with multi_statement disabled, enable it during connection
     client = new_tcp_client


### PR DESCRIPTION
# Add `last_result_size` to ruby bindings

This PR introduces a new method `last_result_size` to the Trilogy gem's Ruby bindings. This method allows users to retrieve the exact byte size of the last result received from a query. The byte size includes not only the raw data but also headers, metadata, and any other protocol overhead.

### Main changes:
    - Added a new method `rb_trilogy_last_result_size` to surface the `conn.recv_buff_len` as a Ruby method.

### Note on the test
The test checks that the `last_result_size` falls within a specific range (150 to 170 bytes). The reason for using a range instead of an exact value is to account for potential changes in the future. For example, changes in how headers or metadata are sent could affect the total byte size. The range provides a buffer to accommodate any of these changes.