### PR TITLE
Add init_command option for parity with mysql2

### DIFF
--- a/contrib/ruby/lib/trilogy.rb
+++ b/contrib/ruby/lib/trilogy.rb
@@ -16,6 +16,8 @@ class Trilogy
     @connected_host = nil
 
     _connect(encoding, charset, options)
+
+    query(options[:init_command]) if options[:init_command]
   end
 
   def connection_options

--- a/contrib/ruby/test/client_test.rb
+++ b/contrib/ruby/test/client_test.rb
@@ -62,6 +62,7 @@ class ClientTest < TrilogyTest
       ssl: true,
       ssl_mode: 4,
       tls_min_version: 3,
+      init_command: "SET SESSION sql_mode = ''",
     }
     assert_equal expected_connection_options, client.connection_options
   end
@@ -1121,5 +1122,12 @@ class ClientTest < TrilogyTest
     assert_operator Errno::ECONNRESET, :===, klass.new
     assert_operator SystemCallError, :===, klass.new
     assert_operator Trilogy::ConnectionError, :===, klass.new
+  end
+
+  def test_init_command
+    client = new_tcp_client(init_command: "SET SQL_MODE=NO_BACKSLASH_ESCAPES")
+
+    result = client.query("SELECT @@sql_mode").first.first
+    assert_equal result, "NO_BACKSLASH_ESCAPES"
   end
 end

--- a/contrib/ruby/test/test_helper.rb
+++ b/contrib/ruby/test/test_helper.rb
@@ -47,11 +47,10 @@ class TrilogyTest < Minitest::Test
       ssl: true,
       ssl_mode: Trilogy::SSL_PREFERRED_NOVERIFY,
       tls_min_version: Trilogy::TLS_VERSION_12,
+      init_command: "SET SESSION sql_mode = ''",
     }.merge(opts)
 
-    c = Trilogy.new defaults
-    c.query "SET SESSION sql_mode = ''"
-    c
+    Trilogy.new defaults
   end
 
   def new_unix_client(socket, opts = {})


### PR DESCRIPTION
This PR adds the `init_command` feature, creating parity with the Ruby `mysql2` gem:

https://github.com/brianmario/mysql2#initial-command-on-connect-and-reconnect

We use this to set `sql_mode` in several legacy application use cases.

I've added a test and adapted this pattern into the default test client factory (where the pattern was already being used in spirit.)