### PR TITLE
Add the new VECTOR type

### DIFF
--- a/inc/trilogy/protocol.h
+++ b/inc/trilogy/protocol.h
@@ -289,6 +289,7 @@ typedef enum {
     XX(TRILOGY_TYPE_YEAR, 0x0d)                                                                                        \
     XX(TRILOGY_TYPE_VARCHAR, 0x0f)                                                                                     \
     XX(TRILOGY_TYPE_BIT, 0x10)                                                                                         \
+    XX(TRILOGY_TYPE_VECTOR, 0xf2)                                                                                      \
     XX(TRILOGY_TYPE_JSON, 0xf5)                                                                                        \
     XX(TRILOGY_TYPE_NEWDECIMAL, 0xf6)                                                                                  \
     XX(TRILOGY_TYPE_ENUM, 0xf7)                                                                                        \

--- a/src/protocol.c
+++ b/src/protocol.c
@@ -926,6 +926,8 @@ int trilogy_build_stmt_execute_packet(trilogy_builder_t *builder, uint32_t stmt_
             case TRILOGY_TYPE_VAR_STRING:
             case TRILOGY_TYPE_STRING:
             case TRILOGY_TYPE_GEOMETRY:
+            case TRILOGY_TYPE_JSON:
+            case TRILOGY_TYPE_VECTOR:
                 CHECKED(trilogy_builder_write_lenenc_buffer(builder, val.as.str.data, val.as.str.len));
 
                 break;
@@ -1059,6 +1061,7 @@ int trilogy_parse_stmt_row_packet(const uint8_t *buff, size_t len, trilogy_colum
             case TRILOGY_TYPE_DECIMAL:
             case TRILOGY_TYPE_NEWDECIMAL:
             case TRILOGY_TYPE_JSON:
+            case TRILOGY_TYPE_VECTOR:
                 CHECKED(trilogy_reader_get_lenenc_buffer(&reader, &out_values[i].as.str.len,
                                                       (const void **)&out_values[i].as.str.data));
 


### PR DESCRIPTION
MySQL 9.0 added a new vector type at the protocol level, so this adds support for it. It is a binary length encoded buffer, so treat it as such.