### PR TITLE
Add Rails setup to README

### DIFF
--- a/contrib/ruby/README.md
+++ b/contrib/ruby/README.md
@@ -22,6 +22,37 @@ Or install it yourself as:
 $ gem install trilogy
 ```
 
+## Rails Setup
+
+After installation, you need to make sure your `config/database.yml` file is using Trilogy.
+
+If you're running MySQL on the same box as Rails, you can use a socket file:
+
+```
+development:
+  adapter: trilogy
+  encoding: utf8mb4
+  database: blog_development
+  pool: 5
+  username: root
+  password:
+  socket: /tmp/mysql.sock
+```
+
+If your MySQL is in another container or across the network, specify the `host` and make sure to require TLS connections:
+
+```
+development:
+  adapter: trilogy
+  encoding: utf8mb4
+  database: blog_development
+  pool: 5
+  username: root
+  password:
+  host: db
+  ssl_mode: :required
+```
+
 ## Usage
 
 ``` ruby


### PR DESCRIPTION
Previously, there was no documentation for how to use the adapter in Rails. With a local MySQL install it's pretty easy - you swap the `adapter` and Trilogy will use the `socket` just like `mysql2` does. But if the app is in Docker, a simple `adapter` change isn't enough; you'll get an `caching_sha2_password requires either TCP with TLS or a unix socket` error that does not tell you how to set up TCP with TLS. You need to set `ssl_mode`, too.

This commit adds a new section to the `contrib/ruby/README.md` to make all this clear.

If there's any additional context that should be included here, I'd be happy to add it. If this change should be in a different file (or a different spot in this file), I can do that, too!