### PR TITLE
Add difference in execute method's response for trilogy and mysql2 to the documentation

### DIFF
--- a/contrib/ruby/README.md
+++ b/contrib/ruby/README.md
@@ -86,3 +86,9 @@ differences:
   the transcoding step up to the caller.
 * There is no `as` query option. Calling `Trilogy::Result#each` will yield an array
   of row values. If you want a hash you should use `Trilogy::Result#each_hash`.
+* When using raw sql with the execute method of active_record
+  (`ActiveRecord::Base.connection.execute`), mysql2 returns a `Mysql2::Result` object
+  whereas trilogy will return an `Activerecord::Result` object.
+  Though this doesn't cause any issues with the execution of the sql query, but if
+  you are trying to use the result from the method you cannot do that exactly like
+  you did with mysql2.


### PR DESCRIPTION
This pr has been created because when we switched to trilogy from mysql2 recently we faced an issue with the usage of ```ActiveRecord::Base.connection.execute```. We are using the response we get from this method call but the way we use this response breaks when we switch to trilogy from mysql2.

This is because of the difference in the response object we get when using **trilogy** and **mysql2**. This difference was not mentioned in the **mysql2 gem compatibility** section of the documentation. This commit adds these changes to the documentation to make it clear.

If there's any additional context that should be included here, I'd be happy to add it.