### PR TITLE
Remove mysql 5.7 from macos

### DIFF
--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -13,7 +13,7 @@ jobs:
     runs-on: macos-latest
     strategy:
       matrix:
-        mysql: ["5.7", "8.0"]
+        mysql: ["8.0"]
     steps:
     - uses: actions/checkout@v4
     - name: Setup MySQL
@@ -32,7 +32,7 @@ jobs:
     runs-on: macos-latest
     strategy:
       matrix:
-        mysql: ["8.0", "8.4"]
+        mysql: ["8.0"]
     steps:
     - uses: actions/checkout@v4
     - name: Setup MySQL

--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -32,7 +32,7 @@ jobs:
     runs-on: macos-latest
     strategy:
       matrix:
-        mysql: ["5.7", "8.0"]
+        mysql: ["8.0", "8.4"]
     steps:
     - uses: actions/checkout@v4
     - name: Setup MySQL


### PR DESCRIPTION
Homebrew will no longer install mysql 5.7, so seems reasonable for us to drop it (at least for macos).