### PR TITLE
Fix max_allowed_packet math

### DIFF
--- a/contrib/ruby/test/client_test.rb
+++ b/contrib/ruby/test/client_test.rb
@@ -832,6 +832,12 @@ class ClientTest < TrilogyTest
 
     assert_equal "trilogy_query_send: TRILOGY_MAX_PACKET_EXCEEDED", exception.message
 
+    exception = assert_raises Trilogy::QueryError do
+      client.query query_for_target_packet_size(32 * 1024 * 1024 + 1)
+    end
+
+    assert_equal "trilogy_query_send: TRILOGY_MAX_PACKET_EXCEEDED", exception.message
+
     assert client.ping
   ensure
     ensure_closed client

--- a/src/builder.c
+++ b/src/builder.c
@@ -182,7 +182,7 @@ int trilogy_builder_write_buffer(trilogy_builder_t *builder, const void *data, s
 
     size_t fragment_remaining = TRILOGY_MAX_PACKET_LEN - builder->fragment_length;
 
-    if (builder->packet_length >= builder->packet_max_length - len) {
+    if (builder->packet_length + len >= builder->packet_max_length) {
         return TRILOGY_MAX_PACKET_EXCEEDED;
     }
 


### PR DESCRIPTION
Prior to this commit our `max_allowed_packed` would fail any time the `len` of the data being written to the buffer was itself greater than the configured `max_allowed_packet`.

This is because both the `len` and the `max_allowed_packet` (aka `builder->packet_max_length`) are unsigned (`size_t`).

This commit bypasses the problem by adding to the left side instead of subtracting from the right.