### PR TITLE
Add an alias for count in Trilogy::Result

### DIFF
--- a/contrib/ruby/lib/trilogy/result.rb
+++ b/contrib/ruby/lib/trilogy/result.rb
@@ -6,6 +6,8 @@ class Trilogy
       rows.count
     end
 
+    alias_method :size, :count
+
     def each_hash
       return enum_for(:each_hash) unless block_given?
 


### PR DESCRIPTION
It was reported in https://github.com/trilogy-libraries/trilogy/issues/206 that `size` was not defined.

Looking at the mysql2 implementation `size` is just an alias to `count`

```
  rb_define_method(cMysql2Result, "count", rb_mysql_result_count, 0);
  rb_define_alias(cMysql2Result, "size", "count");
```

[source](https://github.com/brianmario/mysql2/blob/f6a9b68b42a51d1a370403f11eb88527dcb42dc6/ext/mysql2/result.c#L1241-L1242)

This adds an alias for `count` called `size`