### PR TITLE
Encode column names with encoding of context

### DIFF
--- a/contrib/ruby/ext/trilogy-ruby/cext.c
+++ b/contrib/ruby/ext/trilogy-ruby/cext.c
@@ -811,10 +811,12 @@ static VALUE read_query_response(VALUE vargs)
             }
         }
 
+        rb_encoding *conn_enc = rb_to_encoding(ctx->encoding);
+
 #ifdef HAVE_RB_INTERNED_STR
-        VALUE column_name = rb_interned_str(column.name, column.name_len);
+        VALUE column_name = rb_enc_interned_str(column.name, column.name_len, conn_enc);
 #else
-        VALUE column_name = rb_str_new(column.name, column.name_len);
+        VALUE column_name = rb_enc_str_new(column.name, column.name_len, conn_enc);
         OBJ_FREEZE(column_name);
 #endif
 


### PR DESCRIPTION
We detected some behaviour which might lead to some unexpected failures when migrating from the `mysql2` Adapter to the `trilogy` adapter.
In the result set returned by a query, one can access the column names using the `fields` attribute, however the encoding of these strings is different from the encoding of the database.

## Behaviour in mysql2:

When a query is executed via the database adapter (or rather its client), the column names (in the attribute `fields` of the result) respect the encoding set for the database connection. Running a query on a database with `encoding: utf8mb4` specified in the client creation respects this encoding for the column names, returning the strings with `Encoding:UTF-8` encoding.

## Behaviour in trilogy:

Running the same query on the same database using the trilogy adapter returns the column names encoded with `Encoding:US-ASCII`, ignoring the database encoding.
This might lead to some unexpected encoding issues when the client uses the names from the query to further process the data.

## Tests:

### Behaviour with `mysql2` Adapter:

```ruby
client = Mysql2::Client.new(host: '127.0.0.1', port: 3306, username: 'root', encoding: 'utf8mb4', collation: 'utf8mb4_unicode_520_ci', database: 'mydatabase')

if client.ping
  result = client.query('SELECT * FROM users LIMIT 10')
  puts result.fields.map(&:encoding).join(', ')
end
```

Result: `UTF-8, UTF-8, UTF-8, UTF-8, UTF-8, UTF-8, UTF-8`

### Behaviour with `trilogy` 2.9.0:

```ruby
client = Trilogy.new(host: '127.0.0.1', port: 3306, username: 'root', encoding: 'utf8mb4', collation: 'utf8mb4_unicode_520_ci', database: 'mydatabase')

if client.ping
  result = client.query('SELECT * FROM users LIMIT 10')
  puts result.fields.map(&:encoding).join(', ')
end
```

Result: `US-ASCII, US-ASCII, US-ASCII, US-ASCII, US-ASCII, US-ASCII, US-ASCII`

### Behaviour after patch:

```ruby
client = Trilogy.new(host: '127.0.0.1', port: 3306, username: 'root', encoding: 'utf8mb4', collation: 'utf8mb4_unicode_520_ci', database: 'mydatabase')

if client.ping
  result = client.query('SELECT * FROM users LIMIT 10')
  puts result.fields.map(&:encoding).join(', ')
end
```

Result with patch: `UTF-8, UTF-8, UTF-8, UTF-8, UTF-8, UTF-8, UTF-8`

---

With this patch, trilogy returns the strings in the same encoding as the database, which matches the behaviour of the previous used mysql2 adapter.
I am not sure whether simply returning the strings in ASCII encoding is a deliberate choice or not, therefore feel free to accept or reject this PR, both is fine, I wanted to bring this to attention.

Let me know if you need any other informations, and I'd appreciate someone looking at my usage of Ruby C-API methods to ensure everything is used in its intended way, as I have only limited experience with the C-API.

The CI passed in my fork, see [here](https://github.com/Adrian-Hirt/trilogy/actions/runs/11956285017) and [here](https://github.com/Adrian-Hirt/trilogy/actions/runs/11956285042).

Have a pleasant day!
