### PR TITLE
Fix Ruby 3.4 compatibility

### DIFF
--- a/contrib/ruby/Gemfile.lock
+++ b/contrib/ruby/Gemfile.lock
@@ -2,12 +2,14 @@ PATH
   remote: .
   specs:
     trilogy (2.9.0)
+      bigdecimal
 
 GEM
   remote: https://rubygems.org/
   specs:
     benchmark-ips (2.7.2)
-    minitest (5.11.3)
+    bigdecimal (3.1.8)
+    minitest (5.25.4)
     mysql2 (0.5.6)
     rake (13.0.1)
     rake-compiler (1.0.7)
@@ -24,4 +26,4 @@ DEPENDENCIES
   trilogy!
 
 BUNDLED WITH
-   2.4.12
+   2.5.23

--- a/contrib/ruby/trilogy.gemspec
+++ b/contrib/ruby/trilogy.gemspec
@@ -22,6 +22,8 @@ Gem::Specification.new do |s|
 
   s.require_paths = ["lib"]
 
+  s.add_dependency "bigdecimal"
+
   s.add_development_dependency "rake-compiler", "~> 1.0"
   s.add_development_dependency "minitest", "~> 5.5"
 end


### PR DESCRIPTION
The dependency on `bigdecimal` has to be declared and minitest need to be updated to no longer depend on `mutex_m`