### PR TITLE
Fix Ractor support

### DIFF
--- a/contrib/ruby/lib/trilogy/encoding.rb
+++ b/contrib/ruby/lib/trilogy/encoding.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 class Trilogy
   module Encoding
     RUBY_ENCODINGS = {

--- a/contrib/ruby/test/client_test.rb
+++ b/contrib/ruby/test/client_test.rb
@@ -1131,4 +1131,14 @@ class ClientTest < TrilogyTest
     assert_operator SystemCallError, :===, klass.new
     assert_operator Trilogy::ConnectionError, :===, klass.new
   end
+
+  if defined?(::Ractor)
+    def test_is_ractor_compatible
+      ractor = Ractor.new do
+        client = TrilogyTest.new(nil).new_tcp_client
+        client.query("SELECT 1")
+      end
+      assert_equal [[1]], ractor.take.to_a
+    end
+  end
 end

--- a/contrib/ruby/test/test_helper.rb
+++ b/contrib/ruby/test/test_helper.rb
@@ -21,10 +21,10 @@ if GC.respond_to?(:verify_compaction_references)
 end
 
 class TrilogyTest < Minitest::Test
-  DEFAULT_HOST = ENV["MYSQL_HOST"] || "127.0.0.1"
+  DEFAULT_HOST = (ENV["MYSQL_HOST"] || "127.0.0.1").freeze
   DEFAULT_PORT = (port = ENV["MYSQL_PORT"].to_i) && port != 0 ? port : 3306
-  DEFAULT_USER = ENV["MYSQL_USER"] || "root"
-  DEFAULT_PASS = ENV["MYSQL_PASS"]
+  DEFAULT_USER = (ENV["MYSQL_USER"] || "root").freeze
+  DEFAULT_PASS = ENV["MYSQL_PASS"].freeze
 
   def assert_equal_timestamp(time1, time2)
     assert_equal time1.to_i, time2.to_i


### PR DESCRIPTION
Ref: https://github.com/trilogy-libraries/trilogy/issues/192

The intent was more to allow TruffleRuby not to use a lock, but still, I find it a bit weird that the C extension declare ractor safety and yet isn't usable from a Ractor.