### PR TITLE
Require Ruby 3.0+

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,7 +21,7 @@ jobs:
         include:
           - mysql: "5.7"
             distribution: "debian:buster"
-            ruby: "2.7.8"
+            ruby: "3.0.7"
     steps:
     - uses: actions/checkout@v4
     - name: docker login

--- a/contrib/ruby/trilogy.gemspec
+++ b/contrib/ruby/trilogy.gemspec
@@ -22,6 +22,8 @@ Gem::Specification.new do |s|
 
   s.require_paths = ["lib"]
 
+  s.required_ruby_version = ">= 3.0"
+
   s.add_dependency "bigdecimal"
 
   s.add_development_dependency "rake-compiler", "~> 1.0"


### PR DESCRIPTION
Ruby 3.0 makes timeouts easier to specify on sockets, so to support #218, let's bump to that as our minimum version (previously we did not specify one, but tested Ruby 2.7)