### PR TITLE
Add treatment for proxied ssl connection error

### DIFF
--- a/contrib/ruby/Gemfile.lock
+++ b/contrib/ruby/Gemfile.lock
@@ -11,6 +11,7 @@ GEM
     bigdecimal (3.1.8)
     minitest (5.25.4)
     mysql2 (0.5.6)
+    openssl (3.3.0)
     rake (13.0.1)
     rake-compiler (1.0.7)
       rake
@@ -22,6 +23,7 @@ DEPENDENCIES
   benchmark-ips
   minitest (~> 5.5)
   mysql2
+  openssl (~> 3.0)
   rake-compiler (~> 1.0)
   trilogy!
 

--- a/contrib/ruby/lib/trilogy/error.rb
+++ b/contrib/ruby/lib/trilogy/error.rb
@@ -94,6 +94,7 @@ class Trilogy
       1160 => BaseConnectionError, # ER_NET_ERROR_ON_WRITE
       1161 => BaseConnectionError, # ER_NET_WRITE_INTERRUPTED
       1927 => BaseConnectionError, # ER_CONNECTION_KILLED
+      2026 => BaseConnectionError, # CR_SSL_CONNECTION_ERROR
     }
     class << self
       def from_code(message, code)

--- a/contrib/ruby/trilogy.gemspec
+++ b/contrib/ruby/trilogy.gemspec
@@ -28,4 +28,5 @@ Gem::Specification.new do |s|
 
   s.add_development_dependency "rake-compiler", "~> 1.0"
   s.add_development_dependency "minitest", "~> 5.5"
+  s.add_development_dependency "openssl", "~> 3.0"
 end


### PR DESCRIPTION
This error popped up on our exception tracker:

```
Trilogy::ProtocolError: 2026: TLS/SSL error: Connection timed out (110) (trilogy_query_recv)
```

Rails wrapped it as a `ActiveRecord::StatementInvalid`.

Although [2026 is client error](https://dev.mysql.com/doc/mysql-errors/8.0/en/client-error-reference.html#error_cr_ssl_connection_error) and trilogy itself has no reference to it, when it is used in tandem with a proxy like proxysql that is both a client and a server the error can surface.

I'm proposing wrapping this error with a BaseConnectionError.

This seems to be inline with what mysql2 does https://github.com/brianmario/mysql2/pull/911/files#diff-2c27fbaef84b063b17b3eb069adf94acd254bbbf7e197073e0d2533d8d0441f1R39