### PR TITLE
ruby: Prevent concurrent usage of Trilogy connections

### DIFF
--- a/contrib/ruby/lib/trilogy/error.rb
+++ b/contrib/ruby/lib/trilogy/error.rb
@@ -54,6 +54,12 @@ class Trilogy
     include ConnectionError
   end
 
+  class SynchronizationError < BaseError
+    def initialize(message = "This connection is already in use by another thread or fiber")
+      super
+    end
+  end
+
   # Trilogy::ClientError is the base error type for invalid queries or parameters
   # that shouldn't be retried.
   class ClientError < BaseError

--- a/contrib/ruby/test/client_test.rb
+++ b/contrib/ruby/test/client_test.rb
@@ -705,6 +705,17 @@ class ClientTest < TrilogyTest
     end
   end
 
+  def test_prevent_concurrent_use
+    client = new_tcp_client
+    thread = Thread.new { client.query("SELECT SLEEP(1)") }
+    thread.join(0.2)
+    assert_raises Trilogy::SynchronizationError do
+      client.query("SELECT 1")
+    end
+    thread.join
+    client.close
+  end
+
   USR1 = Class.new(StandardError)
 
   def test_interruptible_when_releasing_gvl


### PR DESCRIPTION
Using a trology connection in a concurrent way will likely lead to various protocol errors, but can also lead to various crashes.

As such it is preferable if Trilogy raises a clear to understand and deterministic error.

I chose to implement this on the Ruby side, because it's simpler and more straightforward.

I initially tried to do it in C, but the `_cb_wait` callback may raise or throw, so we'd need to use `rb_protect`, and release the lock there. The problem is the callback doesn't have access to the `trilogy_context` struct, so can't release the lock.

If we're adament this should be done in C, we'll need a much larger refactor.

cc @tenderlove @jhawthorn 