### PR TITLE
Fix building gem with gcc 15.1.1

### DIFF
--- a/contrib/ruby/ext/trilogy-ruby/extconf.rb
+++ b/contrib/ruby/ext/trilogy-ruby/extconf.rb
@@ -10,7 +10,8 @@ File.binwrite("trilogy.c",
   }.join)
 
 $objs = %w[trilogy.o cast.o cext.o]
-$CFLAGS << " -I #{__dir__}/inc -std=gnu99 -fvisibility=hidden"
+
+append_cflags(["-I #{__dir__}/inc", "-std=gnu99", "-fvisibility=hidden"])
 
 dir_config("openssl")
 


### PR DESCRIPTION
Fixes https://github.com/trilogy-libraries/trilogy/issues/228

```
Installing trilogy 2.9.0 with native extensions
Gem::Ext::BuildError: ERROR: Failed to build gem native extension.

    current directory: /home/hartley/.local/share/mise/installs/ruby/3.4.3/lib/ruby/gems/3.4.0/gems/trilogy-2.9.0/ext/trilogy-ruby
/home/hartley/.local/share/mise/installs/ruby/3.4.3/bin/ruby extconf.rb
checking for CRYPTO_malloc() in -lcrypto... *** extconf.rb failed ***
Could not create Makefile due to some reason, probably lack of necessary
libraries and/or headers.  Check the mkmf.log file for more details.  You may
need configuration options.
```

Previously, trying to build Trilogy with gcc 15.1.1 would result in an error like above. Other gems with c extensions have encountered the same error with gcc 15.1.1, and their fix was to use `append_cflags` instead of modifying `$CFLAGS`. (https://github.com/RubyCrypto/ed25519, https://github.com/tonytonyjan/jaro_winkler/pull/62)

Testing locally, `bundle exec rake build && gem install pkg/*.gem` fails with the above error before this patch but is able to install the gem after.