### PR TITLE
Fix native extension build with GCC 15

### DIFF
--- a/contrib/ruby/ext/trilogy-ruby/extconf.rb
+++ b/contrib/ruby/ext/trilogy-ruby/extconf.rb
@@ -10,7 +10,7 @@ File.binwrite("trilogy.c",
   }.join)
 
 $objs = %w[trilogy.o cast.o cext.o]
-append_cflags(["-I #{__dir__}/inc","-std=gnu99","-fvisibility=hidden"])
+append_cflags(["-I #{__dir__}/inc", "-std=gnu99", "-fvisibility=hidden"])
 
 dir_config("openssl")
 

--- a/contrib/ruby/ext/trilogy-ruby/extconf.rb
+++ b/contrib/ruby/ext/trilogy-ruby/extconf.rb
@@ -10,7 +10,7 @@ File.binwrite("trilogy.c",
   }.join)
 
 $objs = %w[trilogy.o cast.o cext.o]
-$CFLAGS << " -I #{__dir__}/inc -std=gnu99 -fvisibility=hidden"
+append_cflags(["-I #{__dir__}/inc","-std=gnu99","-fvisibility=hidden"])
 
 dir_config("openssl")
 


### PR DESCRIPTION
**OS:** Fedora 42
**Ruby:** 3.2.1
**GCC:** 15.1.1

The native extension build is broken with GCC 15 resulting in the same errors as described here: https://bugs.ruby-lang.org/issues/21290

CFLAGS should be appended with `append_cflags` instead of directly appending them which fixes the problem.