### PR TITLE
Fix the CI setup

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,11 +16,11 @@ jobs:
       fail-fast: false
       matrix:
         mysql: ["5.7", "8.0"]
-        distribution: ["debian:buster", "ubuntu:focal", "ubuntu:bionic"]
+        distribution: ["debian:bookworm", "ubuntu:focal", "ubuntu:bionic"]
         ruby: ["3.3"]
         include:
           - mysql: "5.7"
-            distribution: "debian:buster"
+            distribution: "debian:bookworm"
             ruby: "3.0.7"
     steps:
     - uses: actions/checkout@v4

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,13 +15,9 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        mysql: ["5.7", "8.0"]
+        mysql: ["8.0"]
         distribution: ["debian:bookworm", "ubuntu:focal", "ubuntu:bionic"]
         ruby: ["3.3"]
-        include:
-          - mysql: "5.7"
-            distribution: "debian:bookworm"
-            ruby: "3.0.7"
     steps:
     - uses: actions/checkout@v4
     - name: docker login

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,8 +1,14 @@
-ARG DISTRIBUTION=ubuntu:jammy
+ARG DISTRIBUTION=debian:bookworm
 FROM ${DISTRIBUTION}
 LABEL maintainer="github@github.com"
 
 RUN apt-get update -qq && DEBIAN_FRONTEND=noninteractive apt-get install --no-install-recommends -y build-essential ca-certificates wget libssl-dev default-libmysqlclient-dev clang clang-tools llvm valgrind netcat
+
+# Install libclang-rt-14-dev for Debian Bookworm so that Trilogy builds.
+ARG DISTRIBUTION=debian:bookworm
+RUN if [ "${DISTRIBUTION}" = "debian:bookworm" ]; then \
+    DEBIAN_FRONTEND=noninteractive apt-get install --no-install-recommends -y libclang-rt-14-dev; \
+    fi
 
 RUN update-ca-certificates
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -2,7 +2,7 @@ ARG DISTRIBUTION=debian:bookworm
 FROM ${DISTRIBUTION}
 LABEL maintainer="github@github.com"
 
-RUN apt-get update -qq && DEBIAN_FRONTEND=noninteractive apt-get install --no-install-recommends -y build-essential ca-certificates wget libssl-dev default-libmysqlclient-dev clang clang-tools llvm valgrind netcat
+RUN apt-get update -qq && DEBIAN_FRONTEND=noninteractive apt-get install --no-install-recommends -y build-essential ca-certificates wget libssl-dev default-libmysqlclient-dev clang clang-tools llvm valgrind netcat-traditional
 
 # Install libclang-rt-14-dev for Debian Bookworm so that Trilogy builds.
 ARG DISTRIBUTION=debian:bookworm

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -7,6 +7,7 @@ services:
       dockerfile: test/mysql/Dockerfile
       args:
         - MYSQL_VERSION=${MYSQL_VERSION}
+        - DISTRIBUTION=${DISTRIBUTION}
       cache_from:
         - ghcr.io/trilogy-libraries/trilogy/ci-mysql:${MYSQL_VERSION}-debian
     environment:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -7,7 +7,6 @@ services:
       dockerfile: test/mysql/Dockerfile
       args:
         - MYSQL_VERSION=${MYSQL_VERSION}
-        - DISTRIBUTION=${DISTRIBUTION}
       cache_from:
         - ghcr.io/trilogy-libraries/trilogy/ci-mysql:${MYSQL_VERSION}-debian
     environment:

--- a/script/cibuild
+++ b/script/cibuild
@@ -45,7 +45,7 @@ trap cleanup EXIT
 export CI_MODE=true
 
 if [ -z "$MYSQL_VERSION" ]; then export MYSQL_VERSION=8.0 ; fi
-if [ -z "$DISTRIBUTION" ];  then export DISTRIBUTION=debian:buster ; fi
+if [ -z "$DISTRIBUTION" ];  then export DISTRIBUTION=debian:bookworm ; fi
 if [ -z "$RUBY_VERSION" ];  then export RUBY_VERSION=3.2 ; fi
 
 DISTRIBUTION_SLUG="$(echo "$DISTRIBUTION" | awk '{ gsub(":", "_") ; print $0 }')"

--- a/script/cibuild
+++ b/script/cibuild
@@ -60,6 +60,6 @@ chmod 777 tmp/mysql-certs
 
 docker compose rm --stop --force --volumes
 output_fold "Pull cache image..." docker compose pull app db || true
-output_fold "Bootstrapping container..." docker compose build
+output_fold "Bootstrapping container..." docker compose build --build-arg MYSQL_VERSION=${MYSQL_VERSION} --build-arg DISTRIBUTION=${DISTRIBUTION} --build-arg RUBY_VERSION=${RUBY_VERSION}
 output_fold "Running tests..." docker compose run --rm app
 output_fold "Pushing cache image..." docker compose push app db || true # Don't fail if push fails

--- a/test/mysql/Dockerfile
+++ b/test/mysql/Dockerfile
@@ -1,27 +1,18 @@
-ARG DISTRIBUTION=debian:bookworm
-FROM ${DISTRIBUTION}
+ARG MYSQL_VERSION=8.0
 
-ARG MYSQL_VERSION
+FROM mysql:${MYSQL_VERSION}-debian
 
 # Make all apt-get commands non-interactive. Setting this as an ARG will apply to the entire
 # build phase, but not leak into the final image and run phase.
 ARG DEBIAN_FRONTEND=noninteractive
 
-# Install MySQL from apt repositories.
+# Install the MySQL test package so that we can get test plugins.
+# https://github.com/docker-library/mysql/issues/1040
 RUN set -eux \
     && apt-get update \
-    && apt-get install -y --no-install-recommends \
-        ca-certificates \
-        wget \
-        gnupg \
-        lsb-release \
-    && echo "deb https://repo.mysql.com/apt/debian/ buster mysql-${MYSQL_VERSION}" > /etc/apt/sources.list.d/mysql.list \
-    && apt-key adv --keyserver keyserver.ubuntu.com --recv-keys A8D3785C 3A79BD29 \
-    && apt-get update \
-    && apt-get install -y --no-install-recommends \
-        mysql-server \
-        mysql-client
+    && apt-get install --yes mysql-community-test
 
-# Copy plugins to expected location.
-RUN mkdir -p /usr/lib/mysql/plugin/ \
-    && cp /usr/lib/mysql/plugin/* /usr/lib/mysql/plugin/ || true
+# This is the final stage in which we copy the plugins from the test stage. Doing it this way allows
+# us to not have to install the test package in the final image since we only need the plugins.
+FROM mysql:${MYSQL_VERSION}-debian
+COPY --from=0 /usr/lib/mysql/plugin/ /usr/lib/mysql/plugin/

--- a/test/mysql/Dockerfile
+++ b/test/mysql/Dockerfile
@@ -1,23 +1,27 @@
+ARG DISTRIBUTION=debian:bookworm
+FROM ${DISTRIBUTION}
+
 ARG MYSQL_VERSION
 
-FROM mysql:${MYSQL_VERSION}-debian
 # Make all apt-get commands non-interactive. Setting this as an ARG will apply to the entire
 # build phase, but not leak into the final image and run phase.
 ARG DEBIAN_FRONTEND=noninteractive
 
-# MySQL 5.7 has been EOL'd and is no longer being built by the official mysql docker maintainers:
-# https://github.com/docker-library/mysql/pull/1019
-# Copy the gpg key from the latest MySQL image.
-COPY --from=mysql:8.0-debian /etc/apt/keyrings/mysql.gpg /etc/apt/keyrings/mysql.gpg
-
-# Install the MySQL test package so that we can get test plugins.
-# https://github.com/docker-library/mysql/issues/1040
+# Install MySQL from apt repositories.
 RUN set -eux \
-    # Install MySQL test package.
     && apt-get update \
-    && apt-get install --yes mysql-community-test
+    && apt-get install -y --no-install-recommends \
+        ca-certificates \
+        wget \
+        gnupg \
+        lsb-release \
+    && echo "deb https://repo.mysql.com/apt/debian/ buster mysql-${MYSQL_VERSION}" > /etc/apt/sources.list.d/mysql.list \
+    && apt-key adv --keyserver keyserver.ubuntu.com --recv-keys A8D3785C 3A79BD29 \
+    && apt-get update \
+    && apt-get install -y --no-install-recommends \
+        mysql-server \
+        mysql-client
 
-# This is the final stage inwhich we copy the plugins from the test stage. Doing it this way allows
-# us to not have to install the test package in the final image since we only need the plugins.
-FROM mysql:${MYSQL_VERSION}-debian
-COPY --from=0 /usr/lib/mysql/plugin/ /usr/lib/mysql/plugin/
+# Copy plugins to expected location.
+RUN mkdir -p /usr/lib/mysql/plugin/ \
+    && cp /usr/lib/mysql/plugin/* /usr/lib/mysql/plugin/ || true


### PR DESCRIPTION
```
14 0.204 E: The repository 'http://deb.debian.org/debian buster Release' does not have a Release file.
14 0.204 E: The repository 'http://deb.debian.org/debian-security buster/updates Release' does not have a Release file.
14 0.204 E: The repository 'http://deb.debian.org/debian buster-updates Release' does not have a Release file.
```