### PR TITLE
Use more recent ubuntu releases

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,7 +16,7 @@ jobs:
       fail-fast: false
       matrix:
         mysql: ["8.0"]
-        distribution: ["debian:bookworm", "ubuntu:focal", "ubuntu:bionic"]
+        distribution: ["debian:bookworm", "ubuntu:noble", "ubuntu:jammy", "ubuntu:focal"]
         ruby: ["3.3"]
     steps:
     - uses: actions/checkout@v4

--- a/Dockerfile
+++ b/Dockerfile
@@ -10,6 +10,11 @@ RUN if [ "${DISTRIBUTION}" = "debian:bookworm" ]; then \
     DEBIAN_FRONTEND=noninteractive apt-get install --no-install-recommends -y libclang-rt-14-dev; \
     fi
 
+# Install libclang-rt-18-dev for Ubuntu Noble so that Trilogy builds.
+RUN if [ "${DISTRIBUTION}" = "ubuntu:noble" ]; then \
+    DEBIAN_FRONTEND=noninteractive apt-get install --no-install-recommends -y libclang-rt-18-dev; \
+    fi
+
 RUN update-ca-certificates
 
 RUN wget https://github.com/postmodern/ruby-install/releases/download/v0.9.0/ruby-install-0.9.0.tar.gz && \


### PR DESCRIPTION
Standard support for bionic has ended, so I think we can stop explicitly testing against it. Adding jammy and noble instead.