### PR TITLE
Test Ruby 3.0, 3.1, 3.2

### DIFF
--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -33,7 +33,7 @@ jobs:
     strategy:
       matrix:
         mysql: ["8.0"]
-        ruby: ["3.3", "3.4"]
+        ruby: ["3.0", "3.1", "3.2", "3.3", "3.4"]
     steps:
     - uses: actions/checkout@v4
     - uses: ruby/setup-ruby@v1


### PR DESCRIPTION
We will officially support these Ruby versions, so we should test them.

I don't think we need to test every combination though. This macos build seems easiest since it's using the setup-ruby action.