### PR TITLE
Use pkg_config to locate OpenSSL

### DIFF
--- a/contrib/ruby/ext/trilogy-ruby/extconf.rb
+++ b/contrib/ruby/ext/trilogy-ruby/extconf.rb
@@ -12,7 +12,7 @@ File.binwrite("trilogy.c",
 $objs = %w[trilogy.o cast.o cext.o]
 append_cflags(["-I #{__dir__}/inc", "-std=gnu99", "-fvisibility=hidden"])
 
-dir_config("openssl")
+dir_config("openssl").any? || pkg_config("openssl")
 
 have_library("crypto", "CRYPTO_malloc")
 have_library("ssl", "SSL_new")


### PR DESCRIPTION
When the `--with-openssl-dir=` option is absent, try using `pkg_config` to locate OpenSSL.