### PR TITLE
Ruby 4 support

### DIFF
--- a/contrib/ruby/Gemfile.lock
+++ b/contrib/ruby/Gemfile.lock
@@ -11,7 +11,7 @@ GEM
     bigdecimal (3.1.8)
     minitest (5.25.4)
     mysql2 (0.5.6)
-    rake (13.0.1)
+    rake (13.3.1)
     rake-compiler (1.0.7)
       rake
 


### PR DESCRIPTION
* Account for Ractor#take → #value
* Bump rake for explicit ostruct dep
* Iron out flaky over-exacting allocation tracking test