### PR TITLE
Reduce CI Matrix size

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,7 +20,14 @@ jobs:
       matrix:
         mysql: ["8.0", "8.4", "9.5"]
         distribution: ["debian:bookworm", "ubuntu:noble", "ubuntu:jammy", "ubuntu:focal"]
-        ruby: ["3.3", "3.4", "4.0"]
+        ruby: ["4.0"]
+        include:
+          - distribution: "debian:bookworm"
+            mysql: "8.0"
+            ruby: "3.3"
+          - distribution: "ubuntu:jammy"
+            mysql: "8.0"
+            ruby: "3.3"
     steps:
     - uses: actions/checkout@v6
     - name: docker login

--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -43,8 +43,15 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        mysql: ["8.0", "8.4", "9.6"]
-        ruby: ["3.0", "3.1", "3.2", "3.3", "3.4", "4.0"]
+        include:
+          - mysql: "9.6"
+            ruby: "3.0"
+          - mysql: "9.6"
+            ruby: "4.0"
+          - mysql: "8.0"
+            ruby: "4.0"
+          - mysql: "8.4"
+            ruby: "4.0"
     steps:
     - uses: actions/checkout@v6
     - uses: ruby/setup-ruby@v1


### PR DESCRIPTION
With every extra Ruby and MySQL version the matrix keep getting bigger. I don't think there is value in testing absolutely every combinations.

Testing each Ruby once is enough for instance.