### PR TITLE
Handle server disconnection

### DIFF
--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -43,6 +43,7 @@ jobs:
     name: Test (MariaDB ${{ matrix.mariadb }})
     runs-on: macos-latest
     strategy:
+      fail-fast: false
       matrix:
         mariadb: ["10.6", "10.11", "11.4", "11.8"]
     steps:
@@ -127,6 +128,7 @@ jobs:
     name: Test Ruby (MariaDB ${{ matrix.mariadb }}, Ruby ${{ matrix.ruby }})
     runs-on: macos-latest
     strategy:
+      fail-fast: false
       matrix:
         mariadb: ["10.6", "11.8"]
         ruby: ["4.0"]

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/).
 
 ### Fixed
 
+- Handle server disconnects (Error 4031) correctly by raising `Trilogy::BaseConnectionError` instead of raising a QueryError / TRILOGY_INVALID_SEQUENCE_ID. #257.
 - Column names in results are now encoded using the connection encoding. #210.
 
 ## 2.10.0

--- a/contrib/ruby/lib/trilogy/error.rb
+++ b/contrib/ruby/lib/trilogy/error.rb
@@ -100,6 +100,7 @@ class Trilogy
       1160 => BaseConnectionError, # ER_NET_ERROR_ON_WRITE
       1161 => BaseConnectionError, # ER_NET_WRITE_INTERRUPTED
       1927 => BaseConnectionError, # ER_CONNECTION_KILLED
+      4031 => BaseConnectionError, # Disconnected by server
     }
     class << self
       def from_code(message, code)

--- a/src/packet_parser.c
+++ b/src/packet_parser.c
@@ -74,7 +74,7 @@ size_t trilogy_packet_parser_execute(trilogy_packet_parser_t *parser, const uint
             break;
         }
         case S_SEQ: {
-            if (cur_byte != parser->sequence_number) {
+            if (cur_byte != parser->sequence_number && cur_byte > 0) {
                 *error = TRILOGY_INVALID_SEQUENCE_ID;
                 return i;
             }


### PR DESCRIPTION
Fix: https://github.com/trilogy-libraries/trilogy/issues/257

When the server triggers a disconnection, we receive a packet with sequence 0. Hence we can't be so strict about sequence ordering.