### PR TITLE
Implement Trilogy#abandon_results!

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/).
 
 - Support `caching_sha2_password` over TCP without TLS by requesting the server RSA public key when needed. #26
 - Now raise an explicit error when a single connection is being used concurrently by multiple threads or fibers. #226.
+- `Trilogy#abandon_results!` as an optimized alternative to `client.next_result while client.more_results_exist?`.
 
 ### Fixed
 

--- a/contrib/ruby/test/client_test.rb
+++ b/contrib/ruby/test/client_test.rb
@@ -210,6 +210,21 @@ class ClientTest < TrilogyTest
     refute client.more_results_exist?
   end
 
+  def test_trilogy_abandon_results
+    client = new_tcp_client(multi_statement: true)
+    create_test_table(client)
+
+    client.query("INSERT INTO trilogy_test (int_test) VALUES ('4')")
+    client.query("INSERT INTO trilogy_test (int_test) VALUES ('3')")
+    client.query("INSERT INTO trilogy_test (int_test) VALUES ('1')")
+
+    results = []
+
+    assert_equal [[1, 4]], client.query("SELECT id, int_test FROM trilogy_test WHERE id = 1; SELECT id, int_test FROM trilogy_test WHERE id IN (2, 3); SELECT id, int_test FROM trilogy_test").to_a
+    assert_equal 2, client.abandon_results!
+    assert_equal [[2]], client.query("SELECT 2").to_a
+  end
+
   def test_trilogy_multiple_results_doesnt_allow_multi_statement_queries
     client = new_tcp_client
     create_test_table(client)

--- a/src/client.c
+++ b/src/client.c
@@ -1018,6 +1018,7 @@ int trilogy_drain_results(trilogy_conn_t *conn)
         }
 
         if (current_packet_type(conn) == TRILOGY_PACKET_EOF && conn->packet_buffer.len < 9) {
+            read_eof_packet(conn);
             return TRILOGY_OK;
         }
     }


### PR DESCRIPTION
API is similar to MySQL2, it is functionally equivalent to `client.next_result while client.more_results_exist?` but saves having to parse and allocate the responses.