### PR TITLE
Fix free(): invalid pointer by using free() instead of xfree() in buffer_checkin

### DIFF
--- a/contrib/ruby/ext/trilogy-ruby/cext.c
+++ b/contrib/ruby/ext/trilogy-ruby/cext.c
@@ -134,7 +134,7 @@ static bool buffer_checkin(trilogy_buffer_t *buffer)
     buffer_pool * pool = get_buffer_pool();
 
     if (pool->len >= BUFFER_POOL_MAX_SIZE) {
-        xfree(buffer->buff);
+        free(buffer->buff);
         buffer->buff = NULL;
         buffer->cap = 0;
         return false;


### PR DESCRIPTION
resolved https://github.com/trilogy-libraries/trilogy/issues/268

buffer->buff is allocated via malloc() and may be reallocated by the trilogy C library using realloc(). It must be freed with free(), not Ruby's xfree().

The pool-full path in buffer_checkin was using xfree(), which is inconsistent with buffer_pool_free where free() is correctly used with a note explaining the requirement. In Ruby 4.1.0dev debug builds, this allocator mismatch is detected as heap corruption, causing a 'free(): invalid pointer' crash in buffer_pool_free.