### PR TITLE
Support custom allocators

### DIFF
--- a/contrib/ruby/ext/trilogy-ruby/cast.c
+++ b/contrib/ruby/ext/trilogy-ruby/cast.c
@@ -1,8 +1,6 @@
 #include <ruby.h>
 #include <ruby/encoding.h>
 
-#include <trilogy.h>
-
 #include "trilogy-ruby.h"
 
 #define CAST_STACK_SIZE 64

--- a/contrib/ruby/ext/trilogy-ruby/cext.c
+++ b/contrib/ruby/ext/trilogy-ruby/cext.c
@@ -11,8 +11,6 @@
 #include <unistd.h>
 #include <fcntl.h>
 
-#include <trilogy.h>
-
 #include "trilogy-ruby.h"
 
 typedef struct _buffer_pool_entry_struct {
@@ -41,9 +39,7 @@ static void buffer_pool_free(void *data)
     buffer_pool *pool = (buffer_pool *)data;
     if (pool->capa) {
         for (size_t index = 0; index < pool->len; index++) {
-            // NB: buff was allocated by trilogy/buffer.h using raw `malloc`
-            // hence we must use raw `free`.
-            free(pool->entries[index].buff);
+            xfree(pool->entries[index].buff);
         }
         xfree(pool->entries);
     }
@@ -124,7 +120,7 @@ static void buffer_checkout(trilogy_buffer_t *buffer, size_t initial_capacity)
         buffer->buff = pool->entries[pool->len].buff;
         buffer->cap = pool->entries[pool->len].cap;
     } else {
-        buffer->buff = malloc(initial_capacity);
+        buffer->buff = xmalloc(initial_capacity);
         buffer->cap = initial_capacity;
     }
 }
@@ -134,7 +130,7 @@ static bool buffer_checkin(trilogy_buffer_t *buffer)
     buffer_pool * pool = get_buffer_pool();
 
     if (pool->len >= BUFFER_POOL_MAX_SIZE) {
-        free(buffer->buff);
+        xfree(buffer->buff);
         buffer->buff = NULL;
         buffer->cap = 0;
         return false;

--- a/contrib/ruby/ext/trilogy-ruby/extconf.rb
+++ b/contrib/ruby/ext/trilogy-ruby/extconf.rb
@@ -10,7 +10,7 @@ File.binwrite("trilogy.c",
   }.join)
 
 $objs = %w[trilogy.o cast.o cext.o]
-append_cflags(["-I #{__dir__}/inc", "-std=gnu99", "-fvisibility=hidden"])
+append_cflags(["-I #{__dir__}/inc", "-std=gnu99", "-fvisibility=hidden", "-DTRILOGY_XALLOCATOR", "-g"])
 
 dir_config("openssl").any? || pkg_config("openssl")
 

--- a/contrib/ruby/ext/trilogy-ruby/trilogy-ruby.h
+++ b/contrib/ruby/ext/trilogy-ruby/trilogy-ruby.h
@@ -1,9 +1,11 @@
 #ifndef TRILOGY_RUBY_H
 #define TRILOGY_RUBY_H
 
-#include <stdbool.h>
-
+#include <ruby.h>
+#include <trilogy_xallocator.h>
 #include <trilogy.h>
+
+#include <stdbool.h>
 
 #define TRILOGY_FLAGS_CAST 1
 #define TRILOGY_FLAGS_CAST_BOOLEANS 2

--- a/contrib/ruby/ext/trilogy-ruby/trilogy_xallocator.h
+++ b/contrib/ruby/ext/trilogy-ruby/trilogy_xallocator.h
@@ -1,0 +1,1 @@
+#include <ruby.h>

--- a/example/trilogy_query.c
+++ b/example/trilogy_query.c
@@ -30,7 +30,7 @@ static int execute_query(trilogy_conn_t *conn, const char *sql)
         return rc;
     }
 
-    bool *binary_columns = calloc(column_count, sizeof(bool));
+    bool *binary_columns = xcalloc(column_count, sizeof(bool));
 
     for (uint64_t i = 0; i < column_count; i++) {
         trilogy_column_packet_t column;
@@ -38,7 +38,7 @@ static int execute_query(trilogy_conn_t *conn, const char *sql)
         rc = trilogy_read_full_column(conn, &column);
 
         if (rc < 0) {
-            free(binary_columns);
+            xfree(binary_columns);
             return rc;
         }
 
@@ -58,11 +58,11 @@ static int execute_query(trilogy_conn_t *conn, const char *sql)
 
     // shut scan-build up
     if (column_count == 0) {
-        free(binary_columns);
+        xfree(binary_columns);
         return TRILOGY_OK;
     }
 
-    trilogy_value_t *values = calloc(column_count, sizeof(trilogy_value_t));
+    trilogy_value_t *values = xcalloc(column_count, sizeof(trilogy_value_t));
 
     while ((rc = trilogy_read_full_row(conn, values)) == TRILOGY_OK) {
         for (uint64_t i = 0; i < column_count; i++) {
@@ -84,8 +84,8 @@ static int execute_query(trilogy_conn_t *conn, const char *sql)
         printf("\n");
     }
 
-    free(binary_columns);
-    free(values);
+    xfree(binary_columns);
+    xfree(values);
 
     if (rc == TRILOGY_EOF) {
         rc = TRILOGY_OK;
@@ -123,7 +123,7 @@ int main(int argc, char *argv[])
     if (!(connopt.hostname = getenv("MYSQL_HOST"))) {
         connopt.hostname = DEFAULT_HOST;
     }
-    connopt.hostname = strdup(connopt.hostname);
+    connopt.hostname = xstrdup(connopt.hostname);
 
     const char *port = getenv("MYSQL_TCP_PORT");
 
@@ -138,15 +138,15 @@ int main(int argc, char *argv[])
     if (!(connopt.username = getenv("USER"))) {
         connopt.username = DEFAULT_USER;
     }
-    connopt.username = strdup(connopt.username);
+    connopt.username = xstrdup(connopt.username);
 
     int opt = 0;
     while ((opt = getopt_long(argc, argv, "h:P:s:d:u:p:", longopts, NULL)) != -1) {
         switch (opt) {
         case 'h':
             if (optarg) {
-                free(connopt.hostname);
-                connopt.hostname = strdup(optarg);
+                xfree(connopt.hostname);
+                connopt.hostname = xstrdup(optarg);
             }
             break;
         case 'P':
@@ -156,26 +156,26 @@ int main(int argc, char *argv[])
             break;
         case 's':
             if (optarg) {
-                free(sql);
-                sql = strdup(optarg);
+                xfree(sql);
+                sql = xstrdup(optarg);
             }
             break;
         case 'd':
             if (optarg) {
-                free(connopt.database);
-                connopt.database = strdup(optarg);
+                xfree(connopt.database);
+                connopt.database = xstrdup(optarg);
             }
             break;
         case 'u':
             if (optarg) {
-                free(connopt.username);
-                connopt.username = strdup(optarg);
+                xfree(connopt.username);
+                connopt.username = xstrdup(optarg);
             }
             break;
         case 'p':
             if (optarg) {
-                free(connopt.password);
-                connopt.password = strdup(optarg);
+                xfree(connopt.password);
+                connopt.password = xstrdup(optarg);
                 connopt.password_len = strlen(optarg);
             }
             break;
@@ -224,11 +224,11 @@ int main(int argc, char *argv[])
     fail_on_error(&conn, err, "closing connection");
     fprintf(stderr, "connection closed\n");
 
-    free(connopt.hostname);
-    free(connopt.username);
-    free(sql);
-    free(connopt.database);
-    free(connopt.password);
+    xfree(connopt.hostname);
+    xfree(connopt.username);
+    xfree(sql);
+    xfree(connopt.database);
+    xfree(connopt.password);
 
     trilogy_free(&conn);
     exit(EXIT_SUCCESS);

--- a/inc/trilogy.h
+++ b/inc/trilogy.h
@@ -1,6 +1,7 @@
 #ifndef TRILOGY_H
 #define TRILOGY_H
 
+#include "trilogy/allocator.h"
 #include "trilogy/blocking.h"
 #include "trilogy/client.h"
 #include "trilogy/error.h"

--- a/inc/trilogy/allocator.h
+++ b/inc/trilogy/allocator.h
@@ -1,0 +1,61 @@
+#ifndef TRILOGY_INTERNAL_ALLOCATOR_H
+#define TRILOGY_INTERNAL_ALLOCATOR_H
+
+/* If you build Trilogy with a custom allocator, configure it with
+ * "-D TRILOGY_XALLOCATOR" to use your own allocator that defines xmalloc,
+ * xrealloc, xcalloc, and xfree.
+ *
+ * For example, your `trilogy_xallocator.h` file could look like this:
+ *
+ * ```
+ * #ifndef TRILOGY_XALLOCATOR_H
+ * #define TRILOGY_XALLOCATOR_H
+ * #define xmalloc          my_malloc
+ * #define xrealloc         my_realloc
+ * #define xcalloc          my_calloc
+ * #define xfree            my_free
+ * #endif
+ * ```
+ */
+#ifdef TRILOGY_XALLOCATOR
+    #include "trilogy_xallocator.h"
+#else
+    #ifndef xmalloc
+        /* The malloc function that should be used. This can be overridden with
+         * the TRILOGY_XALLOCATOR define. */
+        #define xmalloc malloc
+    #endif
+
+    #ifndef xrealloc
+        /* The realloc function that should be used. This can be overridden with
+         * the TRILOGY_XALLOCATOR define. */
+        #define xrealloc realloc
+    #endif
+
+    #ifndef xcalloc
+        /* The calloc function that should be used. This can be overridden with
+         * the TRILOGY_XALLOCATOR define. */
+        #define xcalloc calloc
+    #endif
+
+    #ifndef xfree
+        /* The free function that should be used. This can be overridden with
+         * the TRILOGY_XALLOCATOR define. */
+        #define xfree free
+    #endif
+#endif
+
+#include <string.h>
+static inline char *
+xstrdup(const char *str)
+{
+    char *tmp;
+    size_t len = strlen(str) + 1;
+
+    tmp = xmalloc(len);
+    memcpy(tmp, str, len);
+
+    return tmp;
+}
+
+#endif

--- a/src/buffer.c
+++ b/src/buffer.c
@@ -2,6 +2,7 @@
 #include <stdlib.h>
 #include <string.h>
 
+#include "trilogy/allocator.h"
 #include "trilogy/buffer.h"
 #include "trilogy/error.h"
 
@@ -9,7 +10,7 @@ int trilogy_buffer_init(trilogy_buffer_t *buffer, size_t initial_capacity)
 {
     buffer->len = 0;
     buffer->cap = initial_capacity;
-    buffer->buff = malloc(initial_capacity);
+    buffer->buff = xmalloc(initial_capacity);
 
     if (buffer->buff == NULL) {
         return TRILOGY_SYSERR;
@@ -37,7 +38,7 @@ int trilogy_buffer_expand(trilogy_buffer_t *buffer, size_t needed)
             new_cap *= EXPAND_MULTIPLIER;
         }
 
-        uint8_t *new_buff = realloc(buffer->buff, new_cap);
+        uint8_t *new_buff = xrealloc(buffer->buff, new_cap);
         if (new_buff == NULL)
             return TRILOGY_SYSERR;
 
@@ -77,7 +78,7 @@ int trilogy_buffer_write(trilogy_buffer_t *buffer, const uint8_t *ptr, size_t le
 void trilogy_buffer_free(trilogy_buffer_t *buffer)
 {
     if (buffer->buff) {
-        free(buffer->buff);
+        xfree(buffer->buff);
         buffer->buff = NULL;
         buffer->len = buffer->cap = 0;
     }

--- a/src/client.c
+++ b/src/client.c
@@ -7,6 +7,7 @@
 #include <stdlib.h>
 #include <string.h>
 
+#include "trilogy/allocator.h"
 #include "trilogy/client.h"
 #include "trilogy/error.h"
 
@@ -566,7 +567,7 @@ static int encrypt_password_with_public_key(const uint8_t *scramble, size_t scra
         return TRILOGY_MEM_ERROR;
     }
     size_t plaintext_len = password_len + 1;
-    uint8_t *plaintext = malloc(plaintext_len);
+    uint8_t *plaintext = xmalloc(plaintext_len);
 
     if (plaintext == NULL) {
         return TRILOGY_MEM_ERROR;
@@ -585,7 +586,7 @@ static int encrypt_password_with_public_key(const uint8_t *scramble, size_t scra
 
     BIO *bio = BIO_new_mem_buf((void *)key_data, (int)key_data_len);
     if (bio == NULL) {
-        free(plaintext);
+        xfree(plaintext);
         return TRILOGY_OPENSSL_ERR;
     }
 
@@ -600,7 +601,7 @@ static int encrypt_password_with_public_key(const uint8_t *scramble, size_t scra
     if (public_key == NULL) {
         ERR_clear_error();
         memset(plaintext, 0, plaintext_len);
-        free(plaintext);
+        xfree(plaintext);
         return TRILOGY_AUTH_PLUGIN_ERROR;
     }
 
@@ -609,7 +610,7 @@ static int encrypt_password_with_public_key(const uint8_t *scramble, size_t scra
     if (key_size <= 0) {
         EVP_PKEY_free(public_key);
         memset(plaintext, 0, plaintext_len);
-        free(plaintext);
+        xfree(plaintext);
         return TRILOGY_AUTH_PLUGIN_ERROR;
     }
     ciphertext_len = (size_t)key_size;
@@ -628,11 +629,11 @@ static int encrypt_password_with_public_key(const uint8_t *scramble, size_t scra
         RSA_free(public_key);
 #endif
         memset(plaintext, 0, plaintext_len);
-        free(plaintext);
+        xfree(plaintext);
         return TRILOGY_AUTH_PLUGIN_ERROR;
     }
 
-    ciphertext = malloc(ciphertext_len);
+    ciphertext = xmalloc(ciphertext_len);
 
     if (ciphertext == NULL) {
 #if OPENSSL_VERSION_NUMBER >= 0x30000000L
@@ -641,7 +642,7 @@ static int encrypt_password_with_public_key(const uint8_t *scramble, size_t scra
         RSA_free(public_key);
 #endif
         memset(plaintext, 0, plaintext_len);
-        free(plaintext);
+        xfree(plaintext);
         return TRILOGY_MEM_ERROR;
     }
 
@@ -676,13 +677,13 @@ static int encrypt_password_with_public_key(const uint8_t *scramble, size_t scra
 #endif
 
     memset(plaintext, 0, plaintext_len);
-    free(plaintext);
+    xfree(plaintext);
 
     if (rc == TRILOGY_OK) {
         *encrypted_out = ciphertext;
     } else {
         memset(ciphertext, 0, ciphertext_len);
-        free(ciphertext);
+        xfree(ciphertext);
     }
 
     return rc;
@@ -755,7 +756,7 @@ static int handle_fast_auth_fail(trilogy_conn_t *conn, trilogy_handshake_t *hand
 
     rc = send_auth_buffer(conn, encrypted, encrypted_len);
     memset(encrypted, 0, encrypted_len);
-    free(encrypted);
+    xfree(encrypted);
 
     if (rc < 0) {
         return rc;

--- a/src/socket.c
+++ b/src/socket.c
@@ -11,6 +11,7 @@
 #include <stdlib.h>
 #include <unistd.h>
 
+#include "trilogy/allocator.h"
 #include "trilogy/error.h"
 #include "trilogy/socket.h"
 
@@ -21,8 +22,9 @@
 struct trilogy_sock {
     trilogy_sock_t base;
     struct addrinfo *addr;
-    int fd;
     SSL *ssl;
+    int fd;
+    bool freeaddrinfo;
 };
 
 void trilogy_sock_set_fd(trilogy_sock_t *_sock, int fd)
@@ -109,30 +111,30 @@ static int _cb_raw_close(trilogy_sock_t *_sock)
     }
 
     if (sock->addr) {
-        if (sock->base.opts.hostname == NULL && sock->base.opts.path != NULL) {
-            /* We created these with calloc so must free them instead of calling freeaddrinfo */
-            free(sock->addr->ai_addr);
-            free(sock->addr);
-        } else {
+        if (sock->freeaddrinfo) {
             freeaddrinfo(sock->addr);
+        } else {
+            /* We created these with xcalloc so must free them instead of calling freeaddrinfo */
+            xfree(sock->addr->ai_addr);
+            xfree(sock->addr);
         }
     }
 
-    free(sock->base.opts.hostname);
-    free(sock->base.opts.path);
-    free(sock->base.opts.database);
-    free(sock->base.opts.username);
-    free(sock->base.opts.password);
-    free(sock->base.opts.ssl_ca);
-    free(sock->base.opts.ssl_capath);
-    free(sock->base.opts.ssl_cert);
-    free(sock->base.opts.ssl_cipher);
-    free(sock->base.opts.ssl_crl);
-    free(sock->base.opts.ssl_crlpath);
-    free(sock->base.opts.ssl_key);
-    free(sock->base.opts.tls_ciphersuites);
+    xfree(sock->base.opts.hostname);
+    xfree(sock->base.opts.path);
+    xfree(sock->base.opts.database);
+    xfree(sock->base.opts.username);
+    xfree(sock->base.opts.password);
+    xfree(sock->base.opts.ssl_ca);
+    xfree(sock->base.opts.ssl_capath);
+    xfree(sock->base.opts.ssl_cert);
+    xfree(sock->base.opts.ssl_cipher);
+    xfree(sock->base.opts.ssl_crl);
+    xfree(sock->base.opts.ssl_crlpath);
+    xfree(sock->base.opts.ssl_key);
+    xfree(sock->base.opts.tls_ciphersuites);
 
-    free(sock);
+    xfree(sock);
     return rc;
 }
 
@@ -306,12 +308,12 @@ static char *strdupnullok(const char *str)
     if (str == NULL) {
         return NULL;
     }
-    return strdup(str);
+    return xstrdup(str);
 }
 
 trilogy_sock_t *trilogy_sock_new(const trilogy_sockopt_t *opts)
 {
-    struct trilogy_sock *sock = malloc(sizeof(struct trilogy_sock));
+    struct trilogy_sock *sock = xmalloc(sizeof(struct trilogy_sock));
 
     sock->base.connect_cb = _cb_raw_connect;
     sock->base.read_cb = _cb_raw_read;
@@ -328,7 +330,7 @@ trilogy_sock_t *trilogy_sock_new(const trilogy_sockopt_t *opts)
     sock->base.opts.username = strdupnullok(opts->username);
 
     if (sock->base.opts.password) {
-        sock->base.opts.password = malloc(opts->password_len);
+        sock->base.opts.password = xmalloc(opts->password_len);
         memcpy(sock->base.opts.password, opts->password, opts->password_len);
     }
 
@@ -358,6 +360,7 @@ int trilogy_sock_resolve(trilogy_sock_t *_sock)
         char port[6];
         snprintf(port, sizeof(port), "%hu", sock->base.opts.port);
 
+        sock->freeaddrinfo = true;
         if (getaddrinfo(sock->base.opts.hostname, port, &hint, &sock->addr) != 0) {
             return TRILOGY_DNS_ERR;
         }
@@ -368,15 +371,16 @@ int trilogy_sock_resolve(trilogy_sock_t *_sock)
             goto fail;
         }
 
-        sa = calloc(1, sizeof(struct sockaddr_un));
+        sa = xcalloc(1, sizeof(struct sockaddr_un));
         sa->sun_family = AF_UNIX;
         strcpy(sa->sun_path, sock->base.opts.path);
 
-        sock->addr = calloc(1, sizeof(struct addrinfo));
+        sock->addr = xcalloc(1, sizeof(struct addrinfo));
         sock->addr->ai_family = PF_UNIX;
         sock->addr->ai_socktype = SOCK_STREAM;
         sock->addr->ai_addr = (struct sockaddr *)sa;
         sock->addr->ai_addrlen = sizeof(struct sockaddr_un);
+        sock->freeaddrinfo = false;
     } else {
         goto fail;
     }

--- a/test/builder_test.c
+++ b/test/builder_test.c
@@ -41,7 +41,7 @@ TEST test_builder_write_uint8_split_packet()
     ASSERT_OK(err);
 
     size_t len = TRILOGY_MAX_PACKET_LEN - 1;
-    uint8_t *bytes = calloc(len, 1);
+    uint8_t *bytes = xcalloc(len, 1);
 
     err = trilogy_builder_write_buffer(&builder, bytes, len);
     ASSERT_OK(err);
@@ -60,7 +60,7 @@ TEST test_builder_write_uint8_split_packet()
     const uint8_t expected_header2[] = {0x01, 0x00, 0x00, 0x01};
     ASSERT_MEM_EQ(builder.buffer->buff + TRILOGY_MAX_PACKET_LEN + 4, expected_header2, sizeof(expected_header2));
 
-    free(bytes);
+    xfree(bytes);
 
     trilogy_buffer_free(&buff);
     PASS();
@@ -109,7 +109,7 @@ TEST test_builder_write_uint8_exceeds_large_max()
     ASSERT_OK(err);
 
     size_t len = max - 3;
-    uint8_t *bytes = calloc(len, 1);
+    uint8_t *bytes = xcalloc(len, 1);
 
     err = trilogy_builder_write_buffer(&builder, bytes, len);
     ASSERT_OK(err);
@@ -123,7 +123,7 @@ TEST test_builder_write_uint8_exceeds_large_max()
     err = trilogy_builder_write_uint8(&builder, 0x03);
     ASSERT_EQ(TRILOGY_MAX_PACKET_EXCEEDED, err);
 
-    free(bytes);
+    xfree(bytes);
 
     trilogy_buffer_free(&buff);
     PASS();
@@ -318,7 +318,7 @@ TEST test_builder_write_large_buffer()
     ASSERT_OK(err);
 
     size_t len = TRILOGY_MAX_PACKET_LEN + 10;
-    uint8_t *bytes = calloc(len, 1);
+    uint8_t *bytes = xcalloc(len, 1);
 
     err = trilogy_builder_write_buffer(&builder, bytes, len);
     ASSERT_OK(err);
@@ -331,7 +331,7 @@ TEST test_builder_write_large_buffer()
     const uint8_t expected_header2[] = {0x0A, 0x00, 0x00, 0x01};
     ASSERT_MEM_EQ(builder.buffer->buff + TRILOGY_MAX_PACKET_LEN + 4, expected_header2, sizeof(expected_header2));
 
-    free(bytes);
+    xfree(bytes);
 
     trilogy_buffer_free(&buff);
     PASS();

--- a/test/fuzz.c
+++ b/test/fuzz.c
@@ -18,7 +18,7 @@ static void read_columns(trilogy_conn_t *conn, uint64_t column_count) {
 			return;
 	}
 
-	trilogy_value_t *values = calloc(column_count, sizeof(trilogy_value_t));
+	trilogy_value_t *values = xcalloc(column_count, sizeof(trilogy_value_t));
 	if (values) {
 		while (trilogy_read_full_row(conn, values) == TRILOGY_OK) {
 		}


### PR DESCRIPTION
And hook Ruby's allocator in the Ruby extension.

This is largely copied from how prism do it.

We had several bugs in the past where we were freeing memory allocated by Ruby with the system allocator and vice-versa.

It is much simpler if we only use one allocator, and it also has the benefit of feeding Ruby GC with malloc statistics.

Note:

  - Ideally we'd run the test suite again ruby-debug, so that any mistake would be caught on CI.