### PR TITLE
Fix Ruby extension compilation on older rubies and newer Xcode

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,10 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/).
 
 ## Unreleased
 
+### Fixed
+
+- Add workaround to fix compilation on older rubies combined in Xcode 26.4+.
+
 ## 2.12.3
 
 ### Fixed

--- a/contrib/ruby/ext/trilogy-ruby/extconf.rb
+++ b/contrib/ruby/ext/trilogy-ruby/extconf.rb
@@ -10,7 +10,17 @@ File.binwrite("trilogy.c",
   }.join)
 
 $objs = %w[trilogy.o cast.o cext.o]
-append_cflags(["-I #{__dir__}/inc", "-std=gnu99", "-fvisibility=hidden", "-DTRILOGY_XALLOCATOR", "-g"])
+append_cflags([
+  # Ref: https://github.com/trilogy-libraries/trilogy/issues/290
+  # Fix build on older ruby versions and Xcode 26.4+
+  "-Wno-default-const-init-field-unsafe",
+
+  "-I#{__dir__}/inc",
+  "-std=gnu99",
+  "-fvisibility=hidden",
+  "-DTRILOGY_XALLOCATOR",
+  "-g",
+])
 
 dir_config("openssl").any? || pkg_config("openssl")
 


### PR DESCRIPTION
Fix: https://github.com/trilogy-libraries/trilogy/issues/290
Ref: https://bugs.ruby-lang.org/issues/21629

Newer version of xcode emits a new warning by default which cause the build to fail.

Newer rubies have the fix baked in, but to support older ones we need that workaround.