### PR TITLE
cext.c: Copy FD flags after duping

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,10 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/).
 
 ## Unreleased
 
+### Fixed
+
+- Properly set `FD_CLOEXEC` on trilogy sockets created by Ruby to avoid leaking file descriptor on `exec`.
+
 ## 2.12.4
 
 ### Fixed

--- a/contrib/ruby/ext/trilogy-ruby/cext.c
+++ b/contrib/ruby/ext/trilogy-ruby/cext.c
@@ -467,6 +467,17 @@ escape the GVL on each wait operation without going through call_without_gvl */
         return TRILOGY_ERR;
     }
 
+    int flags = fcntl(fd, F_GETFD); /* should not fail except EBADF. */
+    if (flags == -1) {
+        close(newfd);
+        return TRILOGY_ERR;
+    }
+
+    if (fcntl(newfd, F_SETFD, flags) != 0){
+        close(newfd);
+        return TRILOGY_ERR;
+    }
+
     rc = trilogy_connect_set_fd(&ctx->conn, sock, newfd);
     if (rc < 0) {
         trilogy_sock_close(sock);

--- a/contrib/ruby/test/client_test.rb
+++ b/contrib/ruby/test/client_test.rb
@@ -1247,6 +1247,10 @@ class ClientTest < TrilogyTest
     assert_operator Trilogy::ConnectionError, :===, klass.new
   end
 
+  def test_fd_leak_on_exec
+    assert system(RbConfig.ruby, File.expand_path("../fixtures/self-exec.rb", __FILE__))
+  end
+
   if defined?(::Ractor)
     # Remove this when support for Ruby 3.x is dropped
     class ::Ractor; alias value take unless method_defined?(:value); end

--- a/contrib/ruby/test/fixtures/self-exec.rb
+++ b/contrib/ruby/test/fixtures/self-exec.rb
@@ -1,0 +1,30 @@
+# frozen_string_literal: true
+
+require "trilogy"
+
+count = Integer(ENV["COUNT"] || 50)
+
+default_ssl = ENV.fetch("TRILOGY_DEFAULT_SSL", "true") != "false"
+default_ssl_mode = default_ssl ? Trilogy::SSL_PREFERRED_NOVERIFY : Trilogy::SSL_DISABLED
+
+conn = Trilogy.new(
+  host: ENV["MYSQL_HOST"] || "127.0.0.1",
+  port: (port = ENV["MYSQL_PORT"].to_i) && port != 0 ? port : 3306,
+  username: ENV["MYSQL_USER"] || "root",
+  password: ENV["MYSQL_PASS"],
+  ssl: default_ssl,
+  ssl_mode: default_ssl_mode,
+  tls_min_version: Trilogy::TLS_VERSION_12,
+  
+)
+conn.ping
+pipe = IO.pipe.last
+
+if pipe.fileno > 20
+  raise "latest FD reached #{pipe.fileno}, FD leak on exec is likely"
+end
+
+if count > 0
+  ENV["COUNT"] = (count - 1).to_s
+  Process.exec("ruby", $0)
+end


### PR DESCRIPTION
Fix: https://github.com/trilogy-libraries/trilogy/issues/292

`dup(2)` doesn't carry any flags over, meaning we lose important flags like `FD_CLOEXEC`.

NB: still need to add a test

cc @dannyfallon.