### PR TITLE
Properly check buffers back in on unexpected exceptions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,10 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/).
 
 ## Unreleased
 
+### Fixed
+
+- Properly release read buffer on unexpected exception (typically `Timeout.timeout`).
+
 ## 2.12.5
 
 ### Fixed

--- a/contrib/ruby/ext/trilogy-ruby/cext.c
+++ b/contrib/ruby/ext/trilogy-ruby/cext.c
@@ -1065,6 +1065,7 @@ static VALUE execute_read_query_response(struct trilogy_ctx *ctx)
 
     // If we have seen an unexpected exception, jump to it so it gets raised.
     if (state) {
+        rb_trilogy_release_buffer(ctx);
         trilogy_sock_shutdown(ctx->conn.socket);
         rb_jump_tag(state);
     }


### PR DESCRIPTION
This could cause a memory leak, for instance when using `Timeout.timeout`:

```ruby
Timeout.timeout(0.1) do
  trilogy.query('SLEEP(2)') # leak buffer
end
```