### PR TITLE
Add `void *privdata` fields to `trilogy_sockopt_t`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,10 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/).
 
 - Properly release read buffer on unexpected exception (typically `Timeout.timeout`).
 
+### Added
+
+- `trilogy_sockopt_t` now has a `void *privdata` field to allow passing extra info to the callbacks.
+
 ## 2.12.5
 
 ### Fixed

--- a/contrib/ruby/ext/trilogy-ruby/cext.c
+++ b/contrib/ruby/ext/trilogy-ruby/cext.c
@@ -431,6 +431,8 @@ static int _cb_ruby_wait(trilogy_sock_t *sock, trilogy_wait_t wait)
     int state = 0;
     rb_protect(rb_trilogy_wait_protected, (VALUE)&args, &state);
     if (state) {
+        struct trilogy_ctx *ctx = sock->opts.privdata;
+        rb_trilogy_release_buffer(ctx);
         trilogy_sock_shutdown(sock);
         rb_jump_tag(state);
     }
@@ -608,7 +610,9 @@ static int rb_io_descriptor(VALUE io)
 static VALUE rb_trilogy_connect(VALUE self, VALUE raw_socket, VALUE encoding, VALUE charset, VALUE opts)
 {
     struct trilogy_ctx *ctx = get_ctx(self);
-    trilogy_sockopt_t connopt = {0};
+    trilogy_sockopt_t connopt = {
+        .privdata = ctx,
+    };
     trilogy_handshake_t handshake;
     VALUE val;
 

--- a/inc/trilogy/socket.h
+++ b/inc/trilogy/socket.h
@@ -72,6 +72,8 @@ typedef struct {
     TRILOGY_CAPABILITIES_t flags;
 
     size_t max_allowed_packet;
+
+    void *privdata;
 } trilogy_sockopt_t;
 
 typedef struct trilogy_sock_t {


### PR DESCRIPTION
This is a common pattern in libraries meant to be bindable. This allows the binding to pass some extra data to the callbacks.

In the case of the Ruby extension, it allows passing the `struct trilogy_ctx` so that the wait callback can check the buffer back in in case of exception.

Followup: https://github.com/trilogy-libraries/trilogy/pull/295