### PR TITLE
Fix broken links in CONTRIBUTING.md

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -5,7 +5,7 @@
 
 Hi there! We're thrilled that you'd like to contribute to this project. Your help is essential for keeping it great.
 
-Contributions to this project are [released](https://help.github.com/articles/github-terms-of-service/#6-contributions-under-repository-license) to the public under the [project's open source license](LICENSE.md).
+Contributions to this project are [released](https://docs.github.com/en/site-policy/github-terms/github-terms-of-service#6-contributions-under-repository-license) to the public under the [project's open source license](LICENSE).
 
 Please note that this project is released with a [Contributor Code of Conduct](CODE_OF_CONDUCT.md). By participating in this project you agree to abide by its terms.
 


### PR DESCRIPTION
This fixes two broken/outdated links in CONTRIBUTING.md:

- The license link pointed to `LICENSE.md`, but the file in this repository is named `LICENSE`, so the link was broken.
- The GitHub Terms of Service link used the legacy `help.github.com` URL. Updated it to the current canonical URL on `docs.github.com`.

No content changes other than the link targets.