### PR TITLE
Upgrade Bundler used in tests

### DIFF
--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -88,11 +88,15 @@ jobs:
             ruby: "4.0"
           - mysql: "8.4"
             ruby: "4.0"
+    env:
+      BUNDLE_GEMFILE: ${{ github.workspace }}/contrib/ruby/Gemfile
+      BUNDLE_WITHOUT: benchmark
     steps:
     - uses: actions/checkout@v6
     - uses: ruby/setup-ruby@v1
       with:
         ruby-version: ${{ matrix.ruby }}
+        bundler-cache: true
     - name: Setup MySQL
       env:
         MYSQL_VERSION: ${{ matrix.mysql }}
@@ -114,11 +118,6 @@ jobs:
         fi
         $(brew --prefix mysql@${{ matrix.mysql }})/bin/mysql -uroot < test/mysql/docker-entrypoint-initdb.d/x509_user.sql
         $(brew --prefix mysql@${{ matrix.mysql }})/bin/mysql -uroot < test/mysql/docker-entrypoint-initdb.d/cleartext_user.sql
-    - name: Install dependencies
-      run: |
-        cd contrib/ruby
-        bundle config set without benchmark
-        bundle install
     - name: Run tests
       run: |
         cd contrib/ruby
@@ -132,11 +131,15 @@ jobs:
       matrix:
         mariadb: ["10.6", "11.8"]
         ruby: ["4.0"]
+    env:
+      BUNDLE_GEMFILE: ${{ github.workspace }}/contrib/ruby/Gemfile
+      BUNDLE_WITHOUT: benchmark
     steps:
     - uses: actions/checkout@v6
     - uses: ruby/setup-ruby@v1
       with:
         ruby-version: ${{ matrix.ruby }}
+        bundler-cache: true
     - name: Setup MariaDB
       env:
         MARIADB_VERSION: ${{ matrix.mariadb }}

--- a/contrib/ruby/Gemfile.lock
+++ b/contrib/ruby/Gemfile.lock
@@ -28,6 +28,3 @@ DEPENDENCIES
   mysql2
   rake-compiler
   trilogy!
-
-BUNDLED WITH
-   2.5.23


### PR DESCRIPTION
Older versions of Bundler don't appear to be compatible with Ruby HEAD because a pathname constant was removed