### PR TITLE
Default `connect_timeout` to 5 seconds

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,10 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/).
 
 ## Unreleased
 
+### Changed
+
+- The Ruby client now defaults `connect_timeout` to 120 seconds, matching `mysql2`. Pass `connect_timeout: nil` to disable the timeout.
+
 ## 2.12.6
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/).
 
 ### Changed
 
-- The Ruby client now defaults `connect_timeout` to 120 seconds, matching `mysql2`. Pass `connect_timeout: nil` to disable the timeout.
+- The Ruby client now defaults `connect_timeout` to 5 seconds. Pass `connect_timeout: nil` to disable the timeout.
 
 ## 2.12.6
 

--- a/contrib/ruby/README.md
+++ b/contrib/ruby/README.md
@@ -86,3 +86,5 @@ differences:
   the transcoding step up to the caller.
 * There is no `as` query option. Calling `Trilogy::Result#each` will yield an array
   of row values. If you want a hash you should use `Trilogy::Result#each_hash`.
+* The default `connect_timeout` is 5 seconds, while mysql2 defaults to 120 seconds.
+  Pass `connect_timeout: nil` to disable the timeout.

--- a/contrib/ruby/lib/trilogy.rb
+++ b/contrib/ruby/lib/trilogy.rb
@@ -42,8 +42,8 @@ class Trilogy
 
   def initialize(options = {})
     options[:port] = options[:port].to_i if options[:port]
-    # Set default connect_timeout, matching mysql2, to avoid hanging indefinitely on connect
-    options[:connect_timeout] = 120 unless options.key?(:connect_timeout)
+    # Set default connect_timeout to avoid hanging indefinitely on connect
+    options[:connect_timeout] = 5 unless options.key?(:connect_timeout)
     mysql_encoding = options[:encoding] || "utf8mb4"
     encoding = Trilogy::Encoding.find(mysql_encoding)
     charset = Trilogy::Encoding.charset(mysql_encoding)

--- a/contrib/ruby/lib/trilogy.rb
+++ b/contrib/ruby/lib/trilogy.rb
@@ -42,8 +42,6 @@ class Trilogy
 
   def initialize(options = {})
     options[:port] = options[:port].to_i if options[:port]
-    # Set default connect_timeout to avoid hanging indefinitely on connect
-    options[:connect_timeout] = 5 unless options.key?(:connect_timeout)
     mysql_encoding = options[:encoding] || "utf8mb4"
     encoding = Trilogy::Encoding.find(mysql_encoding)
     charset = Trilogy::Encoding.charset(mysql_encoding)
@@ -54,7 +52,7 @@ class Trilogy
     begin
       if host = options[:host]
         port = options[:port] || 3306
-        connect_timeout = options[:connect_timeout] || options[:write_timeout]
+        connect_timeout = options.fetch(:connect_timeout, 5) || options[:write_timeout]
 
         socket = TCPSocket.new(host, port, connect_timeout: connect_timeout)
 

--- a/contrib/ruby/lib/trilogy.rb
+++ b/contrib/ruby/lib/trilogy.rb
@@ -42,6 +42,8 @@ class Trilogy
 
   def initialize(options = {})
     options[:port] = options[:port].to_i if options[:port]
+    # Set default connect_timeout, matching mysql2, to avoid hanging indefinitely on connect
+    options[:connect_timeout] = 120 unless options.key?(:connect_timeout)
     mysql_encoding = options[:encoding] || "utf8mb4"
     encoding = Trilogy::Encoding.find(mysql_encoding)
     charset = Trilogy::Encoding.charset(mysql_encoding)

--- a/contrib/ruby/test/client_test.rb
+++ b/contrib/ruby/test/client_test.rb
@@ -64,7 +64,6 @@ class ClientTest < TrilogyTest
       ssl: true,
       ssl_mode: 4,
       tls_min_version: 3,
-      connect_timeout: 5,
     }
     assert_equal expected_connection_options, client.connection_options
   end
@@ -617,19 +616,16 @@ class ClientTest < TrilogyTest
   end
 
   def test_default_connect_timeout
-    client = new_tcp_client
+    start = Process.clock_gettime(Process::CLOCK_MONOTONIC)
 
-    assert_equal 5, client.connection_options[:connect_timeout]
-  ensure
-    ensure_closed client
-  end
+    assert_raises Trilogy::TimeoutError do
+      # 192.0.2.0/24 is TEST-NET-1 which should only be for docs/examples
+      new_tcp_client(host: "192.0.2.1")
+    end
 
-  def test_default_connect_timeout_not_applied_when_explicitly_nil
-    client = new_tcp_client(connect_timeout: nil)
-
-    assert_nil client.connection_options[:connect_timeout]
-  ensure
-    ensure_closed client
+    # The default is 5s; anything much longer means we hit the OS-level
+    # timeout instead of the default connect_timeout.
+    assert_operator Process.clock_gettime(Process::CLOCK_MONOTONIC) - start, :<, 30
   end
 
   def test_large_query

--- a/contrib/ruby/test/client_test.rb
+++ b/contrib/ruby/test/client_test.rb
@@ -64,7 +64,7 @@ class ClientTest < TrilogyTest
       ssl: true,
       ssl_mode: 4,
       tls_min_version: 3,
-      connect_timeout: 120,
+      connect_timeout: 5,
     }
     assert_equal expected_connection_options, client.connection_options
   end
@@ -619,7 +619,7 @@ class ClientTest < TrilogyTest
   def test_default_connect_timeout
     client = new_tcp_client
 
-    assert_equal 120, client.connection_options[:connect_timeout]
+    assert_equal 5, client.connection_options[:connect_timeout]
   ensure
     ensure_closed client
   end

--- a/contrib/ruby/test/client_test.rb
+++ b/contrib/ruby/test/client_test.rb
@@ -64,6 +64,7 @@ class ClientTest < TrilogyTest
       ssl: true,
       ssl_mode: 4,
       tls_min_version: 3,
+      connect_timeout: 120,
     }
     assert_equal expected_connection_options, client.connection_options
   end
@@ -611,8 +612,24 @@ class ClientTest < TrilogyTest
   def test_connect_timeout_with_only_write_timeout
     assert_raises Trilogy::TimeoutError do
       # 192.0.2.0/24 is TEST-NET-1 which should only be for docs/examples
-      new_tcp_client(host: "192.0.2.1", write_timeout: 0.1)
+      new_tcp_client(host: "192.0.2.1", write_timeout: 0.1, connect_timeout: nil)
     end
+  end
+
+  def test_default_connect_timeout
+    client = new_tcp_client
+
+    assert_equal 120, client.connection_options[:connect_timeout]
+  ensure
+    ensure_closed client
+  end
+
+  def test_default_connect_timeout_not_applied_when_explicitly_nil
+    client = new_tcp_client(connect_timeout: nil)
+
+    assert_nil client.connection_options[:connect_timeout]
+  ensure
+    ensure_closed client
   end
 
   def test_large_query


### PR DESCRIPTION
## Summary

When the `connect_timeout` option is omitted, connecting can currently block indefinitely: `TCPSocket.new` is called with `connect_timeout: nil`, and the C-side handshake wait falls back to `write_timeout`, which is also unlimited by default. The Ruby binding now defaults `connect_timeout` to 5 seconds (originally proposed as 120 seconds to match `mysql2`, lowered to 5 per review feedback).

- The default is applied inline when creating the TCP socket in `Trilogy#initialize`; the passed options hash and `connection_options` are not modified.
- It is only applied when the option is absent: passing `connect_timeout: nil` explicitly disables the timeout and restores the previous behavior, same semantics as `mysql2`.
- An explicit `connect_timeout` value is honored as before.
- Ruby binding only — no changes to the C API defaults or `trilogy_sockopt_t` zero-value semantics.

## Tests

- an omitted `connect_timeout` times out after the 5s default when connecting to a blackholed address (with an upper bound to distinguish it from the OS-level timeout)
- `test_connect_timeout_with_only_write_timeout` now passes `connect_timeout: nil` explicitly — otherwise the default would mask the `write_timeout` fallback path it exercises

## Docs

- README: note the 5s default and the `connect_timeout: nil` opt-out in the "mysql2 gem compatibility" section, since it differs from mysql2's 120s.
- CHANGELOG entry under Unreleased.

🤖 Generated with [Claude Code](https://claude.com/claude-code)