### PR TITLE
CI: compare MySQL major version numerically on macOS

### DIFF
--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -112,8 +112,8 @@ jobs:
         sleep 5
         $(brew --prefix mysql@${{ matrix.mysql }})/bin/mysql -uroot -e 'CREATE DATABASE test'
         $(brew --prefix mysql@${{ matrix.mysql }})/bin/mysql -uroot < test/mysql/docker-entrypoint-initdb.d/caching_sha2_password_user.sql
-        # mysql_native_password plugin was removed in MySQL 9.x
-        if [[ ! "${{ matrix.mysql }}" =~ ^9 ]]; then
+        # mysql_native_password plugin was removed in MySQL 9.0, so skip creating the user there
+        if [[ "${MYSQL_VERSION%%.*}" -lt 9 ]]; then
           $(brew --prefix mysql@${{ matrix.mysql }})/bin/mysql -uroot -e "CREATE USER 'native'@'%'; GRANT ALL PRIVILEGES ON test.* TO 'native'@'%'; ALTER USER 'native'@'%' IDENTIFIED WITH mysql_native_password BY 'password';"
         fi
         $(brew --prefix mysql@${{ matrix.mysql }})/bin/mysql -uroot < test/mysql/docker-entrypoint-initdb.d/x509_user.sql


### PR DESCRIPTION
The `test-ruby-mysql` job skips creating the `mysql_native_password` user on MySQL 9.0+, where the server-side plugin was removed. The check matched the version string with `=~ ^9`, which is wrong now that MySQL uses calendar
versioning (YY.M): the innovation release following 9.7 LTS is 26.7, not 10.0, so `"26.7"` doesn't start with a `9` and would be treated as pre-9.0 — making the job run `CREATE USER ... IDENTIFIED WITH mysql_native_password` against a server that no longer has the plugin.

Compare the major version numerically instead, reusing the `MYSQL_VERSION` env var the step already defines but never used. This matches `test/mysql/docker-entrypoint-initdb.d/native_password_user.sh`, which already
does the same check numerically (verified on bash 3.2.57, the `/bin/bash` on macos-latest runners).

Nothing is failing today: 26.7 isn't in the macOS matrix yet because Homebrew has no `mysql@26.7` formula. This is a preemptive fix.

### References
- [A More Predictable MySQL Release Model: Calendar Versions, LTS, and Innovation](https://blogs.oracle.com/mysql/a-more-predictable-mysql-release-model-calendar-versions-lts-and-innovation)