### PR TITLE
Fix typos in comments and test messages

### DIFF
--- a/contrib/ruby/test/auth_test.rb
+++ b/contrib/ruby/test/auth_test.rb
@@ -73,7 +73,7 @@ class AuthTest < TrilogyTest
       socket = new_tcp_client.query("SHOW VARIABLES LIKE 'socket'").to_a[0][1]
 
       if !File.exist?(socket)
-        skip "cound not find socket at #{socket}"
+        skip "could not find socket at #{socket}"
       end
 
       client = new_unix_client(socket, username: "caching_sha2", password: "password")

--- a/contrib/ruby/test/client_test.rb
+++ b/contrib/ruby/test/client_test.rb
@@ -38,7 +38,7 @@ class ClientTest < TrilogyTest
     socket = new_tcp_client.query("SHOW VARIABLES LIKE 'socket'").to_a[0][1]
 
     if !File.exist?(socket)
-      skip "cound not find socket at #{socket}"
+      skip "could not find socket at #{socket}"
     end
 
     client = new_unix_client(socket)

--- a/inc/trilogy/blocking.h
+++ b/inc/trilogy/blocking.h
@@ -237,7 +237,7 @@ int trilogy_stmt_bind_data(trilogy_conn_t *conn, trilogy_stmt_t *stmt, uint16_t 
 
 /* trilogy_stmt_read_full_row - Read a row from the prepared statement execute response.
  *
- * This should only be called after a sucessful call to trilogy_stmt_execute.
+ * This should only be called after a successful call to trilogy_stmt_execute.
  * You should continue calling this until TRILOGY_EOF is returned. Denoting the end
  * of the result set.
  *

--- a/inc/trilogy/buffer.h
+++ b/inc/trilogy/buffer.h
@@ -68,7 +68,7 @@ int trilogy_buffer_write(trilogy_buffer_t *buffer, const uint8_t *ptr, size_t le
 
 /* trilogy_buffer_free - Free an trilogy_buffer_t's underlying storage. The buffer
  * must be re-initialized with trilogy_buffer_init if it is to be reused. Any
- * operations performed on an unintialized or freed buffer are undefined.
+ * operations performed on an uninitialized or freed buffer are undefined.
  *
  * buffer - An initialized trilogy_buffer_t.
  */

--- a/inc/trilogy/client.h
+++ b/inc/trilogy/client.h
@@ -607,7 +607,7 @@ void trilogy_free(trilogy_conn_t *conn);
  * conn - A pre-initialized trilogy_conn_t pointer.
  *
  * Return values:
- *   TRILOGY_OK                 - The connection was successfuly discarded and freed.
+ *   TRILOGY_OK                 - The connection was successfully discarded and freed.
  *   TRILOGY_SYSERR             - A system error occurred, check errno. The connection wasn't freed.
  */
 int trilogy_discard(trilogy_conn_t *conn);
@@ -665,7 +665,7 @@ int trilogy_stmt_prepare_recv(trilogy_conn_t *conn, trilogy_stmt_t *stmt_out);
 
 /* trilogy_stmt_bind_data_send - Send a prepared statement bind long data command to the server.
  *
- * There is no pairing `trilogy_stmt_bind_data_recv` fucntion to this one because the server
+ * There is no pairing `trilogy_stmt_bind_data_recv` function to this one because the server
  * doesn't send a response to this command.
  *
  * conn      - A connected trilogy_conn_t pointer. Using a disconnected trilogy_conn_t is
@@ -734,7 +734,7 @@ int trilogy_stmt_execute_recv(trilogy_conn_t *conn, uint64_t *column_count_out);
 
 /* trilogy_stmt_read_row - Read a row from the prepared statement execute response.
  *
- * This should only be called after a sucessful call to trilogy_stmt_execute_recv.
+ * This should only be called after a successful call to trilogy_stmt_execute_recv.
  * You should continue calling this until TRILOGY_EOF is returned. Denoting the end
  * of the result set.
  *
@@ -809,7 +809,7 @@ int trilogy_stmt_reset_recv(trilogy_conn_t *conn);
 
 /* trilogy_stmt_close_send - Send a prepared statement close command to the server.
  *
- * There is no pairing `trilogy_stmt_close_recv` fucntion to this one because the server
+ * There is no pairing `trilogy_stmt_close_recv` function to this one because the server
  * doesn't send a response to this command.
  *
  * conn  - A connected trilogy_conn_t pointer. Using a disconnected trilogy_conn_t is

--- a/inc/trilogy/protocol.h
+++ b/inc/trilogy/protocol.h
@@ -317,7 +317,7 @@ typedef enum {
     /* The column is part of a primary key.                                                                            \
      */                                                                                                                \
     XX(TRILOGY_COLUMN_FLAG_PRI_KEY, 0x2)                                                                               \
-    /* The column has the `UNIQUE` flag set. Requring all values to be unique.                                         \
+    /* The column has the `UNIQUE` flag set. Requiring all values to be unique.                                        \
      */                                                                                                                \
     XX(TRILOGY_COLUMN_FLAG_UNIQUE_KEY, 0x4)                                                                            \
     /* The column is part of a key.                                                                                    \
@@ -889,7 +889,7 @@ int trilogy_parse_ok_packet(const uint8_t *buff, size_t len, uint32_t capabiliti
 /* trilogy_parse_eof_packet - Parse an EOF packet.
  *
  * buff         - A pointer to the buffer containing the EOF packet data.
- * len          - The lenght of buff in bytes.
+ * len          - The length of buff in bytes.
  * capabilities - A bitmask of TRILOGY_CAPABILITIES_t flags.
  * out_packet   - Out parameter; A pointer to a pre-allocated
  * trilogy_eof_packet_t.

--- a/src/protocol.c
+++ b/src/protocol.c
@@ -567,7 +567,7 @@ int trilogy_build_auth_packet(trilogy_builder_t *builder, const char *user, cons
     }
 
     if (pass_len > 0) {
-        // Fallback to te default unless we have SHA2 requested
+        // Fallback to the default unless we have SHA2 requested
         if (!strcmp("caching_sha2_password", auth_plugin)) {
             trilogy_pack_scramble_sha2_hash(scramble, pass, pass_len, auth_response, &auth_response_len);
         } else {

--- a/test/mysql/conf.d/8.0/build.cnf
+++ b/test/mysql/conf.d/8.0/build.cnf
@@ -10,7 +10,7 @@ enforce_gtid_consistency = ON
 log_bin = mysql-bin.log
 
 # Since we generate our own certificates for testing purposes, we need to instruct MySQL
-# on where to find them. The certifcates are generated as an entrypoint script located at:
+# on where to find them. The certificates are generated as an entrypoint script located at:
 # mysql/docker-entrypoint-initdb.d/generate_keys.sh
 # The /mysql-certs directory is mounted into both the database container and the app
 # container so that they both can have access to the generated certificates.

--- a/test/mysql/conf.d/8.4/build.cnf
+++ b/test/mysql/conf.d/8.4/build.cnf
@@ -11,7 +11,7 @@ log_bin = mysql-bin.log
 mysql_native_password=ON
 
 # Since we generate our own certificates for testing purposes, we need to instruct MySQL
-# on where to find them. The certifcates are generated as an entrypoint script located at:
+# on where to find them. The certificates are generated as an entrypoint script located at:
 # mysql/docker-entrypoint-initdb.d/generate_keys.sh
 # The /mysql-certs directory is mounted into both the database container and the app
 # container so that they both can have access to the generated certificates.

--- a/test/mysql/conf.d/9.7/build.cnf
+++ b/test/mysql/conf.d/9.7/build.cnf
@@ -11,7 +11,7 @@ enforce_gtid_consistency = ON
 log_bin = mysql-bin.log
 
 # Since we generate our own certificates for testing purposes, we need to instruct MySQL
-# on where to find them. The certifcates are generated as an entrypoint script located at:
+# on where to find them. The certificates are generated as an entrypoint script located at:
 # mysql/docker-entrypoint-initdb.d/generate_keys.sh
 # The /mysql-certs directory is mounted into both the database container and the app
 # container so that they both can have access to the generated certificates.


### PR DESCRIPTION
Fixes 12 typos in doc comments, test skip messages, and MySQL test config comments.
No behavior changes.