### PR TITLE
rb_trilogy_connect: add GC guard for all string configs

### DIFF
--- a/contrib/ruby/ext/trilogy-ruby/cext.c
+++ b/contrib/ruby/ext/trilogy-ruby/cext.c
@@ -607,6 +607,18 @@ static int rb_io_descriptor(VALUE io)
 }
 #endif
 
+static inline VALUE config_set_str(VALUE opts, ID key, char **member)
+{
+    VALUE val = rb_hash_aref(opts, ID2SYM(key));
+    if (NIL_P(val)) {
+        return Qfalse;
+    }
+
+    Check_Type(val, T_STRING);
+    *member = StringValueCStr(val);
+    return val;
+}
+
 static VALUE rb_trilogy_connect(VALUE self, VALUE raw_socket, VALUE encoding, VALUE charset, VALUE opts)
 {
     struct trilogy_ctx *ctx = get_ctx(self);
@@ -662,10 +674,10 @@ static VALUE rb_trilogy_connect(VALUE self, VALUE raw_socket, VALUE encoding, VA
         connopt.max_allowed_packet = NUM2SIZET(val);
     }
 
-    if ((val = rb_hash_lookup(opts, ID2SYM(id_host))) != Qnil) {
-        Check_Type(val, T_STRING);
+    VALUE host = config_set_str(opts, id_host, &connopt.hostname);
+    VALUE path;
 
-        connopt.hostname = StringValueCStr(val);
+    if (host) {
         connopt.port = 3306;
 
         if ((val = rb_hash_lookup(opts, ID2SYM(id_port))) != Qnil) {
@@ -675,26 +687,17 @@ static VALUE rb_trilogy_connect(VALUE self, VALUE raw_socket, VALUE encoding, VA
     } else {
         connopt.path = (char *)"/tmp/mysql.sock";
 
-        if ((val = rb_hash_lookup(opts, ID2SYM(id_socket))) != Qnil) {
-            Check_Type(val, T_STRING);
-            connopt.path = StringValueCStr(val);
-        }
+        path = config_set_str(opts, id_socket, &connopt.path);
     }
 
-    if ((val = rb_hash_aref(opts, ID2SYM(id_username))) != Qnil) {
-        Check_Type(val, T_STRING);
-        connopt.username = StringValueCStr(val);
+    VALUE username = config_set_str(opts, id_username, &connopt.username);
+    VALUE password = config_set_str(opts, id_password, &connopt.password);
+    if (password) {
+        connopt.password_len = RSTRING_LEN(password);
     }
 
-    if ((val = rb_hash_aref(opts, ID2SYM(id_password))) != Qnil) {
-        Check_Type(val, T_STRING);
-        connopt.password = RSTRING_PTR(val);
-        connopt.password_len = RSTRING_LEN(val);
-    }
-
-    if ((val = rb_hash_aref(opts, ID2SYM(id_database))) != Qnil) {
-        Check_Type(val, T_STRING);
-        connopt.database = StringValueCStr(val);
+    VALUE database = config_set_str(opts, id_database, &connopt.database);
+    if (database) {
         connopt.flags |= TRILOGY_CAPABILITIES_CONNECT_WITH_DB;
     }
 
@@ -714,45 +717,14 @@ static VALUE rb_trilogy_connect(VALUE self, VALUE raw_socket, VALUE encoding, VA
         connopt.flags |= TRILOGY_CAPABILITIES_MULTI_STATEMENTS;
     }
 
-    if ((val = rb_hash_aref(opts, ID2SYM(id_ssl_ca))) != Qnil) {
-        Check_Type(val, T_STRING);
-        connopt.ssl_ca = StringValueCStr(val);
-    }
-
-    if ((val = rb_hash_aref(opts, ID2SYM(id_ssl_capath))) != Qnil) {
-        Check_Type(val, T_STRING);
-        connopt.ssl_capath = StringValueCStr(val);
-    }
-
-    if ((val = rb_hash_aref(opts, ID2SYM(id_ssl_cert))) != Qnil) {
-        Check_Type(val, T_STRING);
-        connopt.ssl_cert = StringValueCStr(val);
-    }
-
-    if ((val = rb_hash_aref(opts, ID2SYM(id_ssl_cipher))) != Qnil) {
-        Check_Type(val, T_STRING);
-        connopt.ssl_cipher = StringValueCStr(val);
-    }
-
-    if ((val = rb_hash_aref(opts, ID2SYM(id_ssl_crl))) != Qnil) {
-        Check_Type(val, T_STRING);
-        connopt.ssl_crl = StringValueCStr(val);
-    }
-
-    if ((val = rb_hash_aref(opts, ID2SYM(id_ssl_crlpath))) != Qnil) {
-        Check_Type(val, T_STRING);
-        connopt.ssl_crlpath = StringValueCStr(val);
-    }
-
-    if ((val = rb_hash_aref(opts, ID2SYM(id_ssl_key))) != Qnil) {
-        Check_Type(val, T_STRING);
-        connopt.ssl_key = StringValueCStr(val);
-    }
-
-    if ((val = rb_hash_aref(opts, ID2SYM(id_tls_ciphersuites))) != Qnil) {
-        Check_Type(val, T_STRING);
-        connopt.tls_ciphersuites = StringValueCStr(val);
-    }
+    VALUE ssl_ca = config_set_str(opts, id_ssl_ca, &connopt.ssl_ca);
+    VALUE ssl_capath = config_set_str(opts, id_ssl_capath, &connopt.ssl_capath);
+    VALUE ssl_cert = config_set_str(opts, id_ssl_cert, &connopt.ssl_cert);
+    VALUE ssl_cipher = config_set_str(opts, id_ssl_cipher, &connopt.ssl_cipher);
+    VALUE ssl_crl = config_set_str(opts, id_ssl_crl, &connopt.ssl_crl);
+    VALUE ssl_crlpath = config_set_str(opts, id_ssl_crlpath, &connopt.ssl_crlpath);
+    VALUE ssl_key = config_set_str(opts, id_ssl_key, &connopt.ssl_key);
+    VALUE tls_ciphersuites = config_set_str(opts, id_tls_ciphersuites, &connopt.tls_ciphersuites);
 
     if ((val = rb_hash_aref(opts, ID2SYM(id_tls_min_version))) != Qnil) {
         Check_Type(val, T_FIXNUM);
@@ -790,6 +762,21 @@ static VALUE rb_trilogy_connect(VALUE self, VALUE raw_socket, VALUE encoding, VA
     authenticate(ctx, &handshake, connopt.ssl_mode);
 
     rb_trilogy_release_buffer(ctx);
+
+    // Ensure all our strings are pinned.
+    RB_GC_GUARD(host);
+    RB_GC_GUARD(username);
+    RB_GC_GUARD(password);
+    RB_GC_GUARD(path);
+    RB_GC_GUARD(database);
+    RB_GC_GUARD(ssl_ca);
+    RB_GC_GUARD(ssl_capath);
+    RB_GC_GUARD(ssl_cert);
+    RB_GC_GUARD(ssl_cipher);
+    RB_GC_GUARD(ssl_crl);
+    RB_GC_GUARD(ssl_crlpath);
+    RB_GC_GUARD(ssl_key);
+    RB_GC_GUARD(tls_ciphersuites);
 
     return Qnil;
 }

--- a/contrib/ruby/ext/trilogy-ruby/cext.c
+++ b/contrib/ruby/ext/trilogy-ruby/cext.c
@@ -786,6 +786,7 @@ static VALUE rb_trilogy_change_db(VALUE self, VALUE database)
     struct trilogy_ctx *ctx = get_open_ctx(self);
 
     StringValue(database);
+    database = rb_str_new_frozen(database);
 
     rb_trilogy_acquire_buffer(ctx);
 
@@ -817,6 +818,7 @@ static VALUE rb_trilogy_change_db(VALUE self, VALUE database)
     }
 
     rb_trilogy_release_buffer(ctx);
+    RB_GC_GUARD(database);
 
     return Qtrue;
 }
@@ -1127,6 +1129,7 @@ static VALUE rb_trilogy_query(VALUE self, VALUE query)
 
     StringValue(query);
     query = rb_str_export_to_enc(query, ctx->encoding);
+    query = rb_str_new_frozen(query);
 
     rb_trilogy_acquire_buffer(ctx);
 
@@ -1140,6 +1143,7 @@ static VALUE rb_trilogy_query(VALUE self, VALUE query)
         handle_trilogy_error(ctx, rc, "trilogy_query_send");
     }
 
+    RB_GC_GUARD(query);
     return execute_read_query_response(ctx);
 }
 
@@ -1186,6 +1190,7 @@ static VALUE rb_trilogy_escape(VALUE self, VALUE str)
     rb_encoding *str_enc = rb_enc_get(str);
 
     StringValue(str);
+    str = rb_str_new_frozen(str);
 
     if (!rb_enc_asciicompat(str_enc)) {
         rb_raise(rb_eEncCompatError, "input string must be ASCII-compatible");
@@ -1206,6 +1211,7 @@ static VALUE rb_trilogy_escape(VALUE self, VALUE str)
 
     rb_trilogy_release_buffer(ctx);
 
+    RB_GC_GUARD(str);
     return escaped_string;
 }
 


### PR DESCRIPTION
Fix: https://github.com/trilogy-libraries/trilogy/issues/312

Since we're initializing `connopt` with pointers inside the user provided strings, we must ensure that they are pinned until we return from `rb_trilogy_connect`, otherwise if compaction happens concurrently, or another thread clears the `opts` hash, they could be guarbage collected or moved.

To achieve that, every string option has an associated local variables that is guarded to ensure it isn't optimized out by the compiler.