### PR TITLE
Read the encoding after StringValue in Trilogy#escape

### DIFF
--- a/contrib/ruby/ext/trilogy-ruby/cext.c
+++ b/contrib/ruby/ext/trilogy-ruby/cext.c
@@ -1187,10 +1187,11 @@ static VALUE rb_trilogy_ping(VALUE self)
 static VALUE rb_trilogy_escape(VALUE self, VALUE str)
 {
     struct trilogy_ctx *ctx = get_open_ctx(self);
-    rb_encoding *str_enc = rb_enc_get(str);
 
     StringValue(str);
     str = rb_str_new_frozen(str);
+
+    rb_encoding *str_enc = rb_enc_get(str);
 
     if (!rb_enc_asciicompat(str_enc)) {
         rb_raise(rb_eEncCompatError, "input string must be ASCII-compatible");


### PR DESCRIPTION
`rb_trilogy_escape` reads the encoding before converting the argument:

```c
struct trilogy_ctx *ctx = get_open_ctx(self);
rb_encoding *str_enc = rb_enc_get(str);      // str may not be a String yet

StringValue(str);
str = rb_str_new_frozen(str);

if (!rb_enc_asciicompat(str_enc)) {          // NULL deref
```

For any argument that isn't already a String, `rb_enc_get` returns `NULL` and `rb_enc_asciicompat` dereferences it three lines later. Moving the `rb_enc_get` below the conversion means it reads the encoding of the String actually being escaped, which is what the check is for.

## Reachability

Wider than a hand-written `to_str` class — stdlib `SimpleDelegator` and `DelegateClass(String)` wrapping a String both segfault:

```ruby
require "delegate"
client.escape(SimpleDelegator.new("o'brien"))   # SEGV
```

Local DoS only as far as I can tell; I found no path where untrusted input chooses the *type* of the argument, which is why this is a public PR rather than a private report.

## Verification

Built `main` and the patched tree in the same step that ran the test, Ruby 4.0.6, MySQL 9.6, in a container:

```
argument                 main       with this patch
String (control)         3/3 ok     3/3 ok
plain to_str object      3/3 SEGV   3/3 ok
SimpleDelegator          3/3 SEGV   3/3 ok
```

## Affected

2.9.0, 2.10.0, 2.12.6 and `main` — every version I checked has the `rb_enc_get` above the `StringValue`. `fe2293f` inserted `rb_str_new_frozen` after the `StringValue` but left the `rb_enc_get` where it was.

Found while sweeping native gems for dangling pointers; this one turned up next door to that work rather than out of it.