### PR TITLE
CI: test against MariaDB 12.3 instead of 12.1

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -79,14 +79,14 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        db_version: ["12.1"]
+        db_version: ["12.3"]
         distribution: ["debian:bookworm", "ubuntu:noble", "ubuntu:jammy", "ubuntu:focal"]
         ruby: ["4.0.2"]
         default_ssl: ["true"]
         include:
           - ruby: "3.3.10"
             distribution: "debian:bookworm"
-            db_version: "12.1"
+            db_version: "12.3"
             default_ssl: "true"
           - ruby: "4.0.2"
             distribution: "ubuntu:focal"
@@ -107,7 +107,7 @@ jobs:
           # MariaDB 12.1+ supports caching_sha2_password, so we test with ssl=false
           - ruby: "4.0.2"
             distribution: "ubuntu:focal"
-            db_version: "12.1"
+            db_version: "12.3"
             default_ssl: "false"
     steps:
     - uses: actions/checkout@v7

--- a/test/mariadb/conf.d/12.3/build.cnf
+++ b/test/mariadb/conf.d/12.3/build.cnf
@@ -1,4 +1,4 @@
-# MariaDB 12.1 configuration file
+# MariaDB 12.3 configuration file
 # Mounted into the container at /etc/mysql/conf.d
 
 [mysqld]


### PR DESCRIPTION
MariaDB 12.3 is the new LTS release (GA on 2026-05-28), superseding the 12.1 rolling release.

Refs:
- https://mariadb.org/mariadb-server-12-3-lts-released/
- https://mariadb.com/docs/release-notes/community-server/12.3/12.3.2