### PR TITLE
Prevent synchronization mutex leak

### DIFF
--- a/contrib/ruby/lib/trilogy.rb
+++ b/contrib/ruby/lib/trilogy.rb
@@ -22,15 +22,22 @@ class Trilogy
       super
     end
 
+    NEVER = { Object => :never }.freeze
+    IMMEDIATE = { Object => :immediate }.freeze
+
     synchronized_methods = Trilogy.public_instance_methods(false) - %i(closed? server_version)
     source = synchronized_methods.flat_map do |method|
       [
         "def #{method}(...)",
-          "raise SynchronizationError unless @mutex.try_lock",
-          "begin",
-            "super",
-          "ensure",
-            "@mutex.unlock",
+          "Thread.handle_interrupt(NEVER) do",
+            "raise SynchronizationError unless @mutex.try_lock",
+            "begin",
+              "Thread.handle_interrupt(IMMEDIATE) do",
+                "super",
+              "end",
+            "ensure",
+              "@mutex.unlock",
+            "end",
           "end",
         "end",
       ]


### PR DESCRIPTION
Prior to this change it was possible for the lock to be taken and never released if `Thread.raise` or similar happens between the successful `try_lock` and `begin`.

It's not so easy to reproduce, but in production we've been occasionally seeing individual workers getting repeated
`Trilogy::SynchronizationError` and never recovering. I debugged a bit and the lock was held by the main thread, and the error also happened on the main thread. We've got some poorly placed `Timeout.timeout` calls that I suspect are triggering this.