### PR TITLE
CI: test against MySQL 26.7

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -40,7 +40,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        db_version: ["8.0", "8.4", "9.7"]
+        db_version: ["8.0", "8.4", "9.7", "26.7"]
         distribution: ["debian:bookworm", "ubuntu:noble", "ubuntu:jammy", "ubuntu:focal"]
         default_ssl: ["true"]
         ruby: ["4.0.2"]

--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -18,7 +18,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        mysql: ["8.0", "8.4", "9.7"]
+        mysql: ["8.0", "8.4", "9.7", "26.7"]
     steps:
     - uses: actions/checkout@v7
     - name: Setup MySQL
@@ -80,8 +80,10 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          - mysql: "9.7"
+          - mysql: "26.7"
             ruby: "3.0"
+          - mysql: "26.7"
+            ruby: "4.0"
           - mysql: "9.7"
             ruby: "4.0"
           - mysql: "8.0"

--- a/test/mysql/conf.d/26.7/build.cnf
+++ b/test/mysql/conf.d/26.7/build.cnf
@@ -1,0 +1,21 @@
+# This MySQL configuration file is mounted into the Database container (/etc/mysql/conf.d)
+# at boot and is picked up automatically.
+
+[mysqld]
+
+sql_mode = NO_ENGINE_SUBSTITUTION
+
+server_id = 1
+gtid_mode = ON
+enforce_gtid_consistency = ON
+log_bin = mysql-bin.log
+
+# Since we generate our own certificates for testing purposes, we need to instruct MySQL
+# on where to find them. The certificates are generated as an entrypoint script located at:
+# mysql/docker-entrypoint-initdb.d/generate_keys.sh
+# The /mysql-certs directory is mounted into both the database container and the app
+# container so that they both can have access to the generated certificates.
+# --
+ssl_ca = /mysql-certs/ca.pem
+ssl_cert = /mysql-certs/server-cert.pem
+ssl_key = /mysql-certs/server-key.pem


### PR DESCRIPTION
MySQL 26.7 is the latest innovation release (GA on 2026-07-28), and the first release using the new calendar-based versioning (YY.M.P).

Refs:
- https://blogs.oracle.com/mysql/mysql-july-2026-ga-releases-now-available
- https://dev.mysql.com/doc/relnotes/mysql-ai/en/news-26-7-0.html